### PR TITLE
Replace all `IFLA_` parsing code with netlink-packet-route parsed data

### DIFF
--- a/src/ip/link/detail.rs
+++ b/src/ip/link/detail.rs
@@ -5,6 +5,10 @@ use serde::Serialize;
 
 use crate::link::link_info::CliLinkInfo;
 
+fn should_skip_netns_immutable(val: &Option<bool>) -> bool {
+    matches!(val, None | Some(false))
+}
+
 fn get_addr_gen_mode(af_spec_unspec: &[AfSpecUnspec]) -> String {
     af_spec_unspec
         .iter()
@@ -33,6 +37,11 @@ pub(crate) struct CliLinkInfoDetail {
     allmulti: u32,
     min_mtu: u32,
     max_mtu: u32,
+    #[serde(
+        skip_serializing_if = "should_skip_netns_immutable",
+        rename = "netns-immutable"
+    )]
+    netns_immutable: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     linkinfo: Option<CliLinkInfo>,
     #[serde(skip_serializing_if = "String::is_empty")]
@@ -71,6 +80,7 @@ impl CliLinkInfoDetail {
         let mut inet6_addr_gen_mode = String::new();
         let mut parentbus = String::new();
         let mut parentdev = String::new();
+        let mut netns_immutable = None;
 
         for nl_attr in nl_attrs {
             match nl_attr {
@@ -90,6 +100,7 @@ impl CliLinkInfoDetail {
                 LinkAttribute::GroMaxSize(g) => gro_max_size = *g,
                 LinkAttribute::GsoIpv4MaxSize(g) => gso_ipv4_max_size = *g,
                 LinkAttribute::GroIpv4MaxSize(g) => gro_ipv4_max_size = *g,
+                LinkAttribute::NetnsImmutable(v) => netns_immutable = Some(*v),
                 LinkAttribute::ParentDevName(n) => parentdev = n.clone(),
                 LinkAttribute::ParentDevBusName(n) => parentbus = n.clone(),
                 LinkAttribute::LinkInfo(info) => {
@@ -117,6 +128,7 @@ impl CliLinkInfoDetail {
             gro_max_size,
             gso_ipv4_max_size,
             gro_ipv4_max_size,
+            netns_immutable,
             parentbus,
             parentdev,
         }
@@ -130,6 +142,10 @@ impl std::fmt::Display for CliLinkInfoDetail {
             " promiscuity {} allmulti {} minmtu {} maxmtu {} ",
             self.promiscuity, self.allmulti, self.min_mtu, self.max_mtu,
         )?;
+
+        if self.netns_immutable == Some(true) {
+            write!(f, "netns-immutable ")?;
+        }
 
         if let Some(linkinfo) = &self.linkinfo {
             write!(f, "{linkinfo}")?;

--- a/src/ip/link/detail.rs
+++ b/src/ip/link/detail.rs
@@ -1,24 +1,9 @@
 // SPDX-License-Identifier: MIT
 
-use std::ffi::CStr;
-
-use rtnetlink::{
-    packet_core::{DefaultNla, Nla as _},
-    packet_route::link::{AfSpecInet6, AfSpecUnspec, LinkAttribute},
-};
+use rtnetlink::packet_route::link::{AfSpecInet6, AfSpecUnspec, LinkAttribute};
 use serde::Serialize;
 
 use crate::link::link_info::CliLinkInfo;
-
-// Use constants until support is added to netlink-packet-route
-const IFLA_PARENT_DEV_NAME: u16 = 56;
-const IFLA_PARENT_DEV_BUS_NAME: u16 = 57;
-const IFLA_GRO_MAX_SIZE: u16 = 58;
-const IFLA_TSO_MAX_SIZE: u16 = 59;
-const IFLA_TSO_MAX_SEGS: u16 = 60;
-const IFLA_ALLMULTI: u16 = 61;
-const IFLA_GSO_IPV4_MAX_SIZE: u16 = 63;
-const IFLA_GRO_IPV4_MAX_SIZE: u16 = 64;
 
 fn get_addr_gen_mode(af_spec_unspec: &[AfSpecUnspec]) -> String {
     af_spec_unspec
@@ -40,16 +25,6 @@ fn get_addr_gen_mode(af_spec_unspec: &[AfSpecUnspec]) -> String {
         .next()
         .map(|i| i.to_string())
         .unwrap_or_default()
-}
-fn default_nla_to_string(default_nla: &DefaultNla) -> String {
-    let val_len = default_nla.value_len();
-    let mut val = vec![0u8; val_len];
-    default_nla.emit_value(&mut val);
-    CStr::from_bytes_with_nul(&val)
-        .expect("String nla to be nul-terminated and not contain interior nuls")
-        .to_str()
-        .expect("To be valid UTF-8")
-        .to_string()
 }
 
 #[derive(Serialize)]
@@ -100,6 +75,7 @@ impl CliLinkInfoDetail {
         for nl_attr in nl_attrs {
             match nl_attr {
                 LinkAttribute::Promiscuity(p) => promiscuity = *p,
+                LinkAttribute::AllMulticast(a) => allmulti = *a,
                 LinkAttribute::MinMtu(m) => min_mtu = *m,
                 LinkAttribute::MaxMtu(m) => max_mtu = *m,
                 LinkAttribute::AfSpecUnspec(a) => {
@@ -109,45 +85,13 @@ impl CliLinkInfoDetail {
                 LinkAttribute::NumRxQueues(n) => num_rx_queues = *n,
                 LinkAttribute::GsoMaxSize(g) => gso_max_size = *g,
                 LinkAttribute::GsoMaxSegs(g) => gso_max_segs = *g,
-                LinkAttribute::Other(default_nla) => match default_nla.kind() {
-                    IFLA_PARENT_DEV_BUS_NAME => {
-                        parentbus = default_nla_to_string(default_nla);
-                    }
-                    IFLA_PARENT_DEV_NAME => {
-                        parentdev = default_nla_to_string(default_nla);
-                    }
-                    IFLA_GRO_MAX_SIZE => {
-                        let mut val = [0u8; 4];
-                        default_nla.emit_value(&mut val);
-                        gro_max_size = u32::from_ne_bytes(val);
-                    }
-                    IFLA_TSO_MAX_SIZE => {
-                        let mut val = [0u8; 4];
-                        default_nla.emit_value(&mut val);
-                        tso_max_size = u32::from_ne_bytes(val);
-                    }
-                    IFLA_TSO_MAX_SEGS => {
-                        let mut val = [0u8; 4];
-                        default_nla.emit_value(&mut val);
-                        tso_max_segs = u32::from_ne_bytes(val);
-                    }
-                    IFLA_ALLMULTI => {
-                        let mut val = [0u8; 4];
-                        default_nla.emit_value(&mut val);
-                        allmulti = u32::from_ne_bytes(val);
-                    }
-                    IFLA_GSO_IPV4_MAX_SIZE => {
-                        let mut val = [0u8; 4];
-                        default_nla.emit_value(&mut val);
-                        gso_ipv4_max_size = u32::from_ne_bytes(val);
-                    }
-                    IFLA_GRO_IPV4_MAX_SIZE => {
-                        let mut val = [0u8; 4];
-                        default_nla.emit_value(&mut val);
-                        gro_ipv4_max_size = u32::from_ne_bytes(val);
-                    }
-                    _ => { /* println!("Remains {:?}", default_nla); */ }
-                },
+                LinkAttribute::TsoMaxSize(t) => tso_max_size = *t,
+                LinkAttribute::TsoMaxSegs(t) => tso_max_segs = *t,
+                LinkAttribute::GroMaxSize(g) => gro_max_size = *g,
+                LinkAttribute::GsoIpv4MaxSize(g) => gso_ipv4_max_size = *g,
+                LinkAttribute::GroIpv4MaxSize(g) => gro_ipv4_max_size = *g,
+                LinkAttribute::ParentDevName(n) => parentdev = n.clone(),
+                LinkAttribute::ParentDevBusName(n) => parentbus = n.clone(),
                 LinkAttribute::LinkInfo(info) => {
                     linkinfo = info.as_slice().try_into().ok();
                 }

--- a/src/ip/link/show.rs
+++ b/src/ip/link/show.rs
@@ -188,11 +188,7 @@ pub(crate) async fn parse_nl_msg_to_iface(
                 // TODO: impl Display for State in rust-netlink
                 ret.operstate = format!("{state:?}").to_uppercase()
             }
-            LinkAttribute::TxQueueLen(v) => {
-                if v > 0 {
-                    ret.txqlen = Some(v)
-                }
-            }
+            LinkAttribute::TxQueueLen(v) if v > 0 => ret.txqlen = Some(v),
             LinkAttribute::Group(v) => {
                 ret.group = resolve_ip_link_group_name(v)
             }


### PR DESCRIPTION
All `IFLA_` in this project is parsed by netlink-packet-route now.
Remove unused code.