### PR TITLE
link: Add support for creating dummy interfaces

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,15 @@ pub struct CliError {
     pub msg: String,
 }
 
+impl From<String> for CliError {
+    fn from(msg: String) -> Self {
+        Self {
+            code: DEFAULT_ERROR_CODE,
+            msg,
+        }
+    }
+}
+
 impl From<&str> for CliError {
     fn from(msg: &str) -> Self {
         Self {

--- a/src/ip/link/add.rs
+++ b/src/ip/link/add.rs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+
+use std::collections::HashMap;
+
+use iproute_rs::{CliError, parse_mac_str};
+use rtnetlink::{
+    LinkDummy, LinkMessageBuilder,
+    packet_route::link::{InfoKind, LinkMessage},
+};
+
+use crate::link::CliLinkInfo;
+
+pub(crate) struct LinkAddCommand;
+
+impl LinkAddCommand {
+    pub(crate) const CMD: &'static str = "add";
+
+    pub(crate) fn gen_command() -> clap::Command {
+        clap::Command::new(Self::CMD)
+            .about("add network device")
+            .alias("a")
+            .arg(
+                clap::Arg::new("options")
+                    .action(clap::ArgAction::Append)
+                    .trailing_var_arg(true),
+            )
+    }
+
+    pub(crate) async fn handle(
+        matches: &clap::ArgMatches,
+    ) -> Result<Vec<CliLinkInfo>, CliError> {
+        let opts: Vec<String> = matches
+            .get_many::<String>("options")
+            .unwrap_or_default()
+            .map(|o| o.to_string())
+            .collect();
+
+        let base_conf = LinkBaseConf::parse(opts)?;
+
+        let nl_msg = match base_conf.iface_type {
+            InfoKind::Dummy => {
+                base_conf.apply(LinkDummy::new(&base_conf.name))?
+            }
+            t => {
+                return Err(CliError::from(format!(
+                    "Unsupported device type: {t}"
+                )));
+            }
+        };
+
+        let (connection, handle, _) = rtnetlink::new_connection()?;
+
+        tokio::spawn(connection);
+        handle.link().add(nl_msg).execute().await?;
+
+        Ok(vec![])
+    }
+}
+
+#[derive(Debug)]
+struct LinkBaseConf {
+    // link: Option<String>,
+    name: String,
+    address: Option<String>,
+    iface_type: InfoKind,
+    _iface_specific: Vec<String>,
+}
+
+impl LinkBaseConf {
+    fn apply<T>(
+        &self,
+        mut builder: LinkMessageBuilder<T>,
+    ) -> Result<LinkMessage, CliError> {
+        if let Some(v) = self.address.as_deref() {
+            builder = builder.address(parse_mac_str(v)?)
+        }
+        Ok(builder.build())
+    }
+
+    fn parse(args: Vec<String>) -> Result<Self, CliError> {
+        if let Some(type_index) =
+            args.as_slice().iter().position(|a| a.as_str() == "type")
+            && args.len() > type_index + 1
+        {
+            let iface_type = InfoKind::from(args[type_index + 1].as_str());
+            let mut base_args: Vec<&str> =
+                args[..type_index].iter().map(|s| s.as_str()).collect();
+
+            if base_args.is_empty() {
+                return Err(CliError::from("interface name undefined"));
+            }
+
+            if !base_args.len().is_multiple_of(2) {
+                // iproute2 indicate only `link DEVICE` can be defined before
+                // name
+                if base_args[0] == "link" && base_args.len() >= 3 {
+                    base_args.insert(2, "name");
+                } else {
+                    // assume interface name is the first argument
+                    base_args.insert(0, "name");
+                }
+            }
+
+            let mut base_args_dict: HashMap<&str, &str> =
+                base_args.chunks(2).map(|c| (c[0], c[1])).collect();
+
+            let Some(name) =
+                base_args_dict.remove("name").map(|s| s.to_string())
+            else {
+                return Err(CliError::from("interface name undefined"));
+            };
+
+            let address =
+                base_args_dict.remove("address").map(|s| s.to_string());
+
+            let _iface_specific = if args.len() > type_index + 1 {
+                args[type_index + 2..].to_vec()
+            } else {
+                Vec::new()
+            };
+            Ok(Self {
+                name,
+                address,
+                iface_type,
+                _iface_specific,
+            })
+        } else {
+            Err(CliError::from(
+                "Not enough information: \"type\" argument is required",
+            ))
+        }
+    }
+}

--- a/src/ip/link/cli.rs
+++ b/src/ip/link/cli.rs
@@ -2,7 +2,10 @@
 
 use iproute_rs::CliError;
 
-use super::show::{CliLinkInfo, handle_show};
+use super::{
+    add::LinkAddCommand,
+    show::{CliLinkInfo, handle_show},
+};
 
 pub(crate) struct LinkCommand;
 
@@ -30,13 +33,7 @@ impl LinkCommand {
                             .trailing_var_arg(true),
                     ),
             )
-            .subcommand(
-                clap::Command::new("add").about("add virtual link").arg(
-                    clap::Arg::new("options")
-                        .action(clap::ArgAction::Append)
-                        .trailing_var_arg(true),
-                ),
-            )
+            .subcommand(LinkAddCommand::gen_command())
             .subcommand(
                 clap::Command::new("delete").about("delete virtual link"),
             )
@@ -50,9 +47,9 @@ impl LinkCommand {
     pub(crate) async fn handle(
         matches: &clap::ArgMatches,
     ) -> Result<Vec<CliLinkInfo>, CliError> {
-        if let Some(matches) = matches.subcommand_matches("add") {
-            println!("HAHA {matches:?}");
-            todo!()
+        if let Some(matches) = matches.subcommand_matches(LinkAddCommand::CMD) {
+            LinkAddCommand::handle(matches).await?;
+            Ok(vec![])
         } else if let Some(matches) = matches.subcommand_matches("show") {
             let opts: Vec<&str> = matches
                 .get_many::<String>("options")

--- a/src/ip/link/mod.rs
+++ b/src/ip/link/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 
+mod add;
 mod cli;
 mod detail;
 mod flags;

--- a/src/ip/link/tests/dummy.rs
+++ b/src/ip/link/tests/dummy.rs
@@ -59,8 +59,7 @@ fn with_dummy_iface<T>(name: &str, test: T)
 where
     T: FnOnce() + std::panic::UnwindSafe,
 {
-    exec_cmd(&[
-        "ip",
+    ip_rs_exec_cmd(&[
         "link",
         "add",
         name,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,6 @@ mod result;
 pub use self::{
     color::CliColor,
     error::CliError,
-    mac::mac_to_string,
+    mac::{mac_to_string, parse_mac_str},
     result::{CanDisplay, CanOutput, OutputFormat, print_result_and_exit},
 };

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -2,6 +2,8 @@
 
 use std::fmt::Write;
 
+use crate::CliError;
+
 pub fn mac_to_string(data: &[u8]) -> String {
     let as_ip = data.len() == 4;
     let sep = if as_ip { '.' } else { ':' };
@@ -18,6 +20,16 @@ pub fn mac_to_string(data: &[u8]) -> String {
         }
     }
     rt
+}
+
+pub fn parse_mac_str(s: &str) -> Result<Vec<u8>, CliError> {
+    let mut bytes = Vec::new();
+    for byte in s.split(':') {
+        let v = u8::from_str_radix(byte, 16)
+            .map_err(|_| CliError::from(format!("invalid MAC address: {s}")))?;
+        bytes.push(v);
+    }
+    Ok(bytes)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Intrduced support for 'ip link add <name> type dummy'.
Added handle_add function that parses options and creates a dummy
interface via rtnetlink's LinkDummy builder.

Integration test case is included.