### PR TITLE
link: Add support for creating VLAN interfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,72 @@
+# iproute-rs
+
+Rust drop-in replacement for Linux `iproute2`'s `ip` command. Uses
+`rtnetlink` for Netlink kernel communication. **WIP** — implements
+`ip link show/add` and `ip address show`.
+
+## Build & check
+
+```sh
+cargo build                         # debug binary → target/debug/ip
+cargo build --release
+make check                          # cargo build + sudo cargo test
+```
+
+## Test
+
+Tests **require root** (`sudo`) — `.cargo/config.toml` sets
+`runner = 'sudo'` on Linux.  They create/modify/delete real kernel
+interfaces, so run with care on a dev machine.
+
+The `cargo build` should always be invoked before `cargo test`.
+
+Single test: `cargo test <name>` (runs under sudo automatically).
+
+Integration tests live in `src/ip/{link,address}/tests/`. Pattern:
+run the same command against both system `ip` and compiled `ip-rs`,
+then compare output via `pretty_assertions`.  All test interface
+names use unique prefixes (`tdmy`, `test-br`, `tvlan`, etc.) for
+parallel safety.  Bridge timer values are normalized to avoid
+kernel-timing flakiness.
+
+## Lint & format
+
+Uses **Rust nightly** for formatting.  CI runs these after
+`rustup override set nightly`:
+
+```sh
+cargo fmt --all -- --check          # nightly required
+cargo clippy -- -D warnings
+cargo clippy --tests -- -D warnings
+```
+
+## Project structure
+
+Single crate, not a workspace.
+
+| Crate             | Path              | Description                     |
+|-------------------|-------------------|---------------------------------|
+| `iproute_rs` (lib) | `src/lib.rs`     | Shared: color, error, MAC, ... |
+| `ip` (bin)         | `src/ip/main.rs` | CLI entrypoint (clap + tokio)  |
+
+## Key conventions
+
+- **Edition 2024** with 80-column width, `reorder_imports`,
+  `group_imports = "StdExternalCrate"`,
+  `imports_granularity = "Crate"` (see `.rustfmt.toml`).
+- All source files carry `// SPDX-License-Identifier: MIT`.
+- `rtnetlink` and `netlink-packet-route` pulled from git via
+  `[patch.crates-io]` (not crates.io).
+- Async: `#[tokio::main(flavor = "current_thread")]` —
+  single-threaded.
+- CLI with `clap`; command aliases mirror `iproute2`
+  (e.g. `link` → `lin`, `li`, `l`).
+- `Cargo.lock` is **not** committed (gitignored).
+
+## Netlink connection pattern
+
+```rust
+let (connection, handle, _) = rtnetlink::new_connection()?;
+tokio::spawn(connection);
+// use handle to send Netlink messages
+```

--- a/src/ip/link/add.rs
+++ b/src/ip/link/add.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 
+use futures_util::TryStreamExt;
 use iproute_rs::{CliError, parse_mac_str};
 use rtnetlink::{
     LinkDummy, LinkMessageBuilder,
@@ -37,9 +38,15 @@ impl LinkAddCommand {
 
         let base_conf = LinkBaseConf::parse(opts)?;
 
+        let (connection, handle, _) = rtnetlink::new_connection()?;
+        tokio::spawn(connection);
+
         let nl_msg = match base_conf.iface_type {
             InfoKind::Dummy => {
                 base_conf.apply(LinkDummy::new(&base_conf.name))?
+            }
+            InfoKind::Vlan => {
+                base_conf.apply(base_conf.apply_vlan(&handle).await?)?
             }
             t => {
                 return Err(CliError::from(format!(
@@ -48,9 +55,6 @@ impl LinkAddCommand {
             }
         };
 
-        let (connection, handle, _) = rtnetlink::new_connection()?;
-
-        tokio::spawn(connection);
         handle.link().add(nl_msg).execute().await?;
 
         Ok(vec![])
@@ -58,12 +62,12 @@ impl LinkAddCommand {
 }
 
 #[derive(Debug)]
-struct LinkBaseConf {
-    // link: Option<String>,
-    name: String,
-    address: Option<String>,
-    iface_type: InfoKind,
-    _iface_specific: Vec<String>,
+pub(crate) struct LinkBaseConf {
+    pub(crate) link: Option<String>,
+    pub(crate) name: String,
+    pub(crate) address: Option<String>,
+    pub(crate) iface_type: InfoKind,
+    pub(crate) iface_specific: Vec<String>,
 }
 
 impl LinkBaseConf {
@@ -75,6 +79,19 @@ impl LinkBaseConf {
             builder = builder.address(parse_mac_str(v)?)
         }
         Ok(builder.build())
+    }
+
+    pub(crate) async fn get_ifindex_by_name(
+        &self,
+        handle: &rtnetlink::Handle,
+        name: &str,
+    ) -> Result<u32, CliError> {
+        let mut links =
+            handle.link().get().match_name(name.to_string()).execute();
+        let link = links.try_next().await?.ok_or_else(|| {
+            CliError::from(format!("Device \"{name}\" does not exist"))
+        })?;
+        Ok(link.header.index)
     }
 
     fn parse(args: Vec<String>) -> Result<Self, CliError> {
@@ -112,8 +129,9 @@ impl LinkBaseConf {
 
             let address =
                 base_args_dict.remove("address").map(|s| s.to_string());
+            let link = base_args_dict.remove("link").map(|s| s.to_string());
 
-            let _iface_specific = if args.len() > type_index + 1 {
+            let iface_specific = if args.len() > type_index + 1 {
                 args[type_index + 2..].to_vec()
             } else {
                 Vec::new()
@@ -121,13 +139,101 @@ impl LinkBaseConf {
             Ok(Self {
                 name,
                 address,
+                link,
                 iface_type,
-                _iface_specific,
+                iface_specific,
             })
         } else {
             Err(CliError::from(
                 "Not enough information: \"type\" argument is required",
             ))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(input: &[&str]) -> Vec<String> {
+        input.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn parse_basic_dummy() {
+        let conf =
+            LinkBaseConf::parse(args(&["eth0", "type", "dummy"])).unwrap();
+        assert_eq!(conf.name, "eth0");
+        assert_eq!(conf.iface_type, InfoKind::Dummy);
+        assert!(conf.address.is_none());
+        assert!(conf.link.is_none());
+        assert!(conf.iface_specific.is_empty());
+    }
+
+    #[test]
+    fn parse_with_address() {
+        let conf = LinkBaseConf::parse(args(&[
+            "name",
+            "eth0",
+            "address",
+            "00:11:22:33:44:55",
+            "type",
+            "dummy",
+        ]))
+        .unwrap();
+        assert_eq!(conf.name, "eth0");
+        assert_eq!(conf.address.as_deref(), Some("00:11:22:33:44:55"));
+        assert_eq!(conf.iface_type, InfoKind::Dummy);
+    }
+
+    #[test]
+    fn parse_with_link() {
+        let conf = LinkBaseConf::parse(args(&[
+            "link", "eth0", "name", "eth0.1", "type", "vlan", "id", "100",
+        ]))
+        .unwrap();
+        assert_eq!(conf.name, "eth0.1");
+        assert_eq!(conf.link.as_deref(), Some("eth0"));
+        assert_eq!(conf.iface_type, InfoKind::Vlan);
+        assert_eq!(conf.iface_specific, vec!["id", "100"]);
+    }
+
+    #[test]
+    fn parse_link_no_name_fails() {
+        let err = LinkBaseConf::parse(args(&["link", "eth0", "type", "dummy"]))
+            .unwrap_err();
+        assert!(err.msg.contains("name"));
+    }
+
+    #[test]
+    fn parse_missing_type() {
+        let err = LinkBaseConf::parse(args(&["eth0"])).unwrap_err();
+        assert!(err.msg.contains("type"));
+    }
+
+    #[test]
+    fn parse_type_at_end() {
+        let err = LinkBaseConf::parse(args(&["eth0", "type"])).unwrap_err();
+        assert!(err.msg.contains("type"));
+    }
+
+    #[test]
+    fn parse_empty_args() {
+        let err = LinkBaseConf::parse(args(&[])).unwrap_err();
+        assert!(err.msg.contains("type"));
+    }
+
+    #[test]
+    fn parse_no_name() {
+        let err = LinkBaseConf::parse(args(&["type", "dummy"])).unwrap_err();
+        assert!(err.msg.contains("name"));
+    }
+
+    #[test]
+    fn parse_odd_args_without_link() {
+        let conf =
+            LinkBaseConf::parse(args(&["foo", "bar", "baz", "type", "dummy"]))
+                .unwrap();
+        assert_eq!(conf.name, "foo");
     }
 }

--- a/src/ip/link/ifaces/vlan.rs
+++ b/src/ip/link/ifaces/vlan.rs
@@ -1,13 +1,21 @@
 // SPDX-License-Identifier: MIT
 
-use rtnetlink::packet_route::link::{InfoVlan, VlanFlags};
+use iproute_rs::CliError;
+use rtnetlink::{
+    LinkMessageBuilder, LinkVlan, QosMapping,
+    packet_route::link::{InfoVlan, VlanFlags, VlanProtocol, VlanQosMapping},
+};
 use serde::Serialize;
 
-#[derive(Serialize)]
+use crate::link::LinkBaseConf;
+
+#[derive(Serialize, Default)]
 pub(crate) struct CliLinkInfoDataVlan {
     protocol: String,
     id: u16,
     flags: Vec<String>,
+    ingress_qos: Vec<String>,
+    egress_qos: Vec<String>,
 }
 
 impl From<&[InfoVlan]> for CliLinkInfoDataVlan {
@@ -15,6 +23,8 @@ impl From<&[InfoVlan]> for CliLinkInfoDataVlan {
         let mut id = 0;
         let mut flags = Vec::new();
         let mut protocol = String::new();
+        let mut ingress_qos = Vec::new();
+        let mut egress_qos = Vec::new();
 
         for nla in info {
             match nla {
@@ -37,7 +47,25 @@ impl From<&[InfoVlan]> for CliLinkInfoDataVlan {
                     }
                 }
                 InfoVlan::Protocol(v) => {
-                    protocol = v.to_string().to_uppercase();
+                    protocol = match v {
+                        VlanProtocol::Ieee8021Q => "802.1Q".to_string(),
+                        VlanProtocol::Ieee8021Ad => "802.1ad".to_string(),
+                        _ => v.to_string(),
+                    };
+                }
+                InfoVlan::IngressQos(mappings) => {
+                    for mapping in mappings {
+                        if let VlanQosMapping::Mapping(from, to) = mapping {
+                            ingress_qos.push(format!("{from}:{to}"));
+                        }
+                    }
+                }
+                InfoVlan::EgressQos(mappings) => {
+                    for mapping in mappings {
+                        if let VlanQosMapping::Mapping(from, to) = mapping {
+                            egress_qos.push(format!("{from}:{to}"));
+                        }
+                    }
                 }
                 _ => (),
             }
@@ -47,16 +75,181 @@ impl From<&[InfoVlan]> for CliLinkInfoDataVlan {
             id,
             flags,
             protocol,
+            ingress_qos,
+            egress_qos,
         }
     }
 }
 
+impl LinkBaseConf {
+    pub(crate) async fn apply_vlan(
+        &self,
+        handle: &rtnetlink::Handle,
+    ) -> Result<LinkMessageBuilder<LinkVlan>, CliError> {
+        let link_name = self
+            .link
+            .as_deref()
+            .ok_or_else(|| CliError::from("VLAN requires link device"))?;
+
+        let link_ifindex = self.get_ifindex_by_name(handle, link_name).await?;
+
+        let mut builder =
+            LinkMessageBuilder::<LinkVlan>::new(&self.name).link(link_ifindex);
+        let mut vlan_id = None;
+        let mut ingress_qos = Vec::new();
+        let mut egress_qos = Vec::new();
+        let mut flags = VlanFlags::empty();
+        let mut flag_mask = VlanFlags::empty();
+
+        macro_rules! set_flag {
+            ($v:expr, $flag:ident) => {
+                match $v.as_str() {
+                    "on" => {
+                        flags |= VlanFlags::$flag;
+                        flag_mask |= VlanFlags::$flag;
+                    }
+                    "off" => {
+                        flag_mask |= VlanFlags::$flag;
+                    }
+                    _ => {
+                        return Err(CliError::from(format!(
+                            "{} must be on or off, got {}",
+                            stringify!($flag),
+                            $v
+                        )));
+                    }
+                }
+            };
+        }
+
+        let mut iter = self.iface_specific.iter();
+        while let Some(key) = iter.next() {
+            match key.as_str() {
+                "id" => {
+                    let Some(v) = iter.next() else {
+                        return Err(CliError::from("VLAN id requires a value"));
+                    };
+                    let id = v.parse::<u16>().map_err(|_| {
+                        CliError::from(format!("Invalid VLAN id: {v}"))
+                    })?;
+                    builder = builder.id(id);
+                    vlan_id = Some(id);
+                }
+                "protocol" => {
+                    let Some(v) = iter.next() else {
+                        return Err(CliError::from(
+                            "VLAN protocol requires a value",
+                        ));
+                    };
+                    let proto = match v.to_lowercase().as_str() {
+                        "802.1q" => VlanProtocol::Ieee8021Q,
+                        "802.1ad" => VlanProtocol::Ieee8021Ad,
+                        _ => {
+                            return Err(CliError::from(format!(
+                                "Unknown VLAN protocol: {v}"
+                            )));
+                        }
+                    };
+                    builder = builder.protocol(proto);
+                }
+                "reorder_hdr" => {
+                    let Some(v) = iter.next() else {
+                        return Err(CliError::from(
+                            "reorder_hdr requires a value",
+                        ));
+                    };
+                    set_flag!(v, ReorderHdr);
+                }
+                "gvrp" => {
+                    let Some(v) = iter.next() else {
+                        return Err(CliError::from("gvrp requires a value"));
+                    };
+                    set_flag!(v, Gvrp);
+                }
+                "mvrp" => {
+                    let Some(v) = iter.next() else {
+                        return Err(CliError::from("mvrp requires a value"));
+                    };
+                    set_flag!(v, Mvrp);
+                }
+                "loose_binding" => {
+                    let Some(v) = iter.next() else {
+                        return Err(CliError::from(
+                            "loose_binding requires a value",
+                        ));
+                    };
+                    set_flag!(v, LooseBinding);
+                }
+                "bridge_binding" => {
+                    let Some(v) = iter.next() else {
+                        return Err(CliError::from(
+                            "bridge_binding requires a value",
+                        ));
+                    };
+                    set_flag!(v, BridgeBinding);
+                }
+                "ingress-qos-map" => {
+                    let Some(v) = iter.next() else {
+                        return Err(CliError::from(
+                            "ingress-qos-map requires a from:to mapping",
+                        ));
+                    };
+                    let (from, to) = parse_qos_map(v)?;
+                    ingress_qos.push(QosMapping { from, to });
+                }
+                "egress-qos-map" => {
+                    let Some(v) = iter.next() else {
+                        return Err(CliError::from(
+                            "egress-qos-map requires a from:to mapping",
+                        ));
+                    };
+                    let (from, to) = parse_qos_map(v)?;
+                    egress_qos.push(QosMapping { from, to });
+                }
+                _ => {
+                    return Err(CliError::from(format!(
+                        "Unknown VLAN argument: {key}"
+                    )));
+                }
+            }
+        }
+
+        let Some(_) = vlan_id else {
+            return Err(CliError::from("VLAN id is required"));
+        };
+
+        if flag_mask != VlanFlags::empty() {
+            builder = builder.flags(flags, flag_mask);
+        }
+
+        if !ingress_qos.is_empty() || !egress_qos.is_empty() {
+            builder = builder.qos(ingress_qos, egress_qos);
+        }
+
+        Ok(builder)
+    }
+}
+
+fn parse_qos_map(s: &str) -> Result<(u32, u32), CliError> {
+    let Some((from, to)) = s.split_once(':') else {
+        return Err(CliError::from(format!(
+            "Invalid QoS mapping, expected from:to, got {s}"
+        )));
+    };
+    let from = from.parse::<u32>().map_err(|_| {
+        CliError::from(format!("Invalid QoS map 'from' value: {from}"))
+    })?;
+    let to = to.parse::<u32>().map_err(|_| {
+        CliError::from(format!("Invalid QoS map 'to' value: {to}"))
+    })?;
+    Ok((from, to))
+}
+
 impl std::fmt::Display for CliLinkInfoDataVlan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "protocol {} ", self.protocol)?;
-        write!(f, "id {} ", self.id)?;
+        write!(f, "protocol {} id {}", self.protocol, self.id)?;
         if !self.flags.is_empty() {
-            write!(f, "<{}>", self.flags.as_slice().join(","))?;
+            write!(f, " <{}>", self.flags.as_slice().join(","))?;
         }
         Ok(())
     }

--- a/src/ip/link/mod.rs
+++ b/src/ip/link/mod.rs
@@ -12,6 +12,7 @@ mod show;
 mod tests;
 
 pub(crate) use self::{
+    add::LinkBaseConf,
     cli::LinkCommand,
     show::{CliLinkInfo, handle_show},
 };

--- a/src/ip/link/tests/mod.rs
+++ b/src/ip/link/tests/mod.rs
@@ -5,4 +5,5 @@ mod bridge;
 mod color;
 mod dummy;
 mod loopback;
+mod vlan;
 mod vxlan;

--- a/src/ip/link/tests/vlan.rs
+++ b/src/ip/link/tests/vlan.rs
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: MIT
+
+use crate::tests::{exec_cmd, ip_rs_exec_cmd};
+
+#[test]
+fn test_link_show_vlan() {
+    let vlan_name = "tvlan20";
+
+    with_vlan_iface(vlan_name, &[], || {
+        let expected_output = exec_cmd(&["ip", "link", "show", vlan_name]);
+
+        let our_output = ip_rs_exec_cmd(&["link", "show", vlan_name]);
+
+        pretty_assertions::assert_eq!(&expected_output, &our_output);
+    })
+}
+
+#[test]
+fn test_link_detailed_show_vlan() {
+    let vlan_name = "tvlan10";
+
+    with_vlan_iface(vlan_name, &[], || {
+        let expected_output =
+            exec_cmd(&["ip", "-d", "link", "show", vlan_name]);
+
+        let our_output = ip_rs_exec_cmd(&["-d", "link", "show", vlan_name]);
+
+        pretty_assertions::assert_eq!(&expected_output, &our_output);
+    })
+}
+
+#[test]
+fn test_vlan_protocol() {
+    let vlan_name = "tvlan_proto";
+
+    with_vlan_iface(vlan_name, &["protocol", "802.1ad"], || {
+        let expected_output =
+            exec_cmd(&["ip", "-d", "link", "show", vlan_name]);
+
+        let our_output = ip_rs_exec_cmd(&["-d", "link", "show", vlan_name]);
+
+        assert!(expected_output.contains("protocol 802.1ad"));
+
+        pretty_assertions::assert_eq!(&expected_output, &our_output);
+    })
+}
+
+#[test]
+fn test_vlan_reorder_hdr_on() {
+    let vlan_name = "tvlan_rh_on";
+
+    with_vlan_iface(vlan_name, &["reorder_hdr", "on"], || {
+        let expected_output =
+            exec_cmd(&["ip", "-d", "link", "show", vlan_name]);
+
+        let our_output = ip_rs_exec_cmd(&["-d", "link", "show", vlan_name]);
+
+        assert!(expected_output.contains("REORDER_HDR"));
+
+        pretty_assertions::assert_eq!(&expected_output, &our_output);
+    })
+}
+
+#[test]
+fn test_vlan_reorder_hdr_off() {
+    let vlan_name = "tvlan_rh_off";
+
+    with_vlan_iface(vlan_name, &["reorder_hdr", "off"], || {
+        let expected_output =
+            exec_cmd(&["ip", "-d", "link", "show", vlan_name]);
+
+        let our_output = ip_rs_exec_cmd(&["-d", "link", "show", vlan_name]);
+
+        assert!(!expected_output.contains("REORDER_HDR"));
+
+        pretty_assertions::assert_eq!(&expected_output, &our_output);
+    })
+}
+
+#[test]
+fn test_vlan_gvrp_on() {
+    let vlan_name = "tvlan_gvrp_on";
+
+    with_vlan_iface(vlan_name, &["gvrp", "on"], || {
+        let expected_output =
+            exec_cmd(&["ip", "-d", "link", "show", vlan_name]);
+
+        let our_output = ip_rs_exec_cmd(&["-d", "link", "show", vlan_name]);
+
+        assert!(expected_output.contains("GVRP"));
+
+        pretty_assertions::assert_eq!(&expected_output, &our_output);
+    })
+}
+
+#[test]
+fn test_vlan_gvrp_off() {
+    let vlan_name = "tvlan_gvrp_off";
+
+    with_vlan_iface(vlan_name, &["gvrp", "off"], || {
+        let expected_output =
+            exec_cmd(&["ip", "-d", "link", "show", vlan_name]);
+
+        let our_output = ip_rs_exec_cmd(&["-d", "link", "show", vlan_name]);
+
+        assert!(!expected_output.contains("GVRP"));
+
+        pretty_assertions::assert_eq!(&expected_output, &our_output);
+    })
+}
+
+#[test]
+fn test_vlan_mvrp_on() {
+    let vlan_name = "tvlan_mvrp_on";
+
+    with_vlan_iface(vlan_name, &["mvrp", "on"], || {
+        let expected_output =
+            exec_cmd(&["ip", "-d", "link", "show", vlan_name]);
+
+        let our_output = ip_rs_exec_cmd(&["-d", "link", "show", vlan_name]);
+
+        assert!(expected_output.contains("MVRP"));
+
+        pretty_assertions::assert_eq!(&expected_output, &our_output);
+    })
+}
+
+#[test]
+fn test_vlan_mvrp_off() {
+    let vlan_name = "tvlan_mvrp_off";
+
+    with_vlan_iface(vlan_name, &["mvrp", "off"], || {
+        let expected_output =
+            exec_cmd(&["ip", "-d", "link", "show", vlan_name]);
+
+        let our_output = ip_rs_exec_cmd(&["-d", "link", "show", vlan_name]);
+
+        assert!(!expected_output.contains("MVRP"));
+
+        pretty_assertions::assert_eq!(&expected_output, &our_output);
+    })
+}
+
+#[test]
+fn test_vlan_loose_binding_on() {
+    let vlan_name = "tvlan_lb_on";
+
+    with_vlan_iface(vlan_name, &["loose_binding", "on"], || {
+        let expected_output =
+            exec_cmd(&["ip", "-d", "link", "show", vlan_name]);
+
+        let our_output = ip_rs_exec_cmd(&["-d", "link", "show", vlan_name]);
+
+        assert!(expected_output.contains("LOOSE_BINDING"));
+
+        pretty_assertions::assert_eq!(&expected_output, &our_output);
+    })
+}
+
+#[test]
+fn test_vlan_loose_binding_off() {
+    let vlan_name = "tvlan_lb_off";
+
+    with_vlan_iface(vlan_name, &["loose_binding", "off"], || {
+        let expected_output =
+            exec_cmd(&["ip", "-d", "link", "show", vlan_name]);
+
+        let our_output = ip_rs_exec_cmd(&["-d", "link", "show", vlan_name]);
+
+        assert!(!expected_output.contains("LOOSE_BINDING"));
+
+        pretty_assertions::assert_eq!(&expected_output, &our_output);
+    })
+}
+
+#[test]
+fn test_vlan_bridge_binding_on() {
+    let vlan_name = "tvlan_bb_on";
+
+    with_vlan_iface(vlan_name, &["bridge_binding", "on"], || {
+        let expected_output =
+            exec_cmd(&["ip", "-d", "link", "show", vlan_name]);
+
+        let our_output = ip_rs_exec_cmd(&["-d", "link", "show", vlan_name]);
+
+        assert!(expected_output.contains("BRIDGE_BINDING"));
+
+        pretty_assertions::assert_eq!(&expected_output, &our_output);
+    })
+}
+
+#[test]
+fn test_vlan_bridge_binding_off() {
+    let vlan_name = "tvlan_bb_off";
+
+    with_vlan_iface(vlan_name, &["bridge_binding", "off"], || {
+        let expected_output =
+            exec_cmd(&["ip", "-d", "link", "show", vlan_name]);
+
+        let our_output = ip_rs_exec_cmd(&["-d", "link", "show", vlan_name]);
+
+        assert!(!expected_output.contains("BRIDGE_BINDING"));
+
+        pretty_assertions::assert_eq!(&expected_output, &our_output);
+    })
+}
+
+#[test]
+fn test_vlan_all_flags_on() {
+    let vlan_name = "tvn_all_flg";
+
+    with_vlan_iface(
+        vlan_name,
+        &[
+            "protocol",
+            "802.1ad",
+            "reorder_hdr",
+            "on",
+            "gvrp",
+            "on",
+            "loose_binding",
+            "on",
+            "bridge_binding",
+            "on",
+        ],
+        || {
+            let expected_output =
+                exec_cmd(&["ip", "-d", "link", "show", vlan_name]);
+
+            let our_output = ip_rs_exec_cmd(&["-d", "link", "show", vlan_name]);
+
+            assert!(expected_output.contains("protocol 802.1ad"));
+            assert!(expected_output.contains("REORDER_HDR"));
+            assert!(expected_output.contains("GVRP"));
+            assert!(expected_output.contains("LOOSE_BINDING"));
+            assert!(expected_output.contains("BRIDGE_BINDING"));
+
+            pretty_assertions::assert_eq!(&expected_output, &our_output);
+        },
+    )
+}
+
+fn with_vlan_iface<T>(vlan_name: &str, opts: &[&str], test: T)
+where
+    T: FnOnce() + std::panic::UnwindSafe,
+{
+    let parent_name = format!("p{vlan_name}");
+
+    // create parent dummy interface using ip-rs
+    ip_rs_exec_cmd(&["link", "add", &parent_name, "type", "dummy"]);
+    exec_cmd(&["ip", "link", "set", &parent_name, "up"]);
+
+    let mut args = vec![
+        "link",
+        "add",
+        "link",
+        &parent_name,
+        "name",
+        vlan_name,
+        "type",
+        "vlan",
+        "id",
+        "100",
+    ];
+
+    args.extend_from_slice(opts);
+
+    ip_rs_exec_cmd(&args);
+    exec_cmd(&["ip", "link", "set", vlan_name, "up"]);
+
+    let result = std::panic::catch_unwind(|| {
+        test();
+    });
+
+    // clean up
+    exec_cmd(&["ip", "link", "del", vlan_name]);
+    exec_cmd(&["ip", "link", "del", &parent_name]);
+    assert!(result.is_ok())
+}

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -34,7 +34,25 @@ pub fn parse_mac_str(s: &str) -> Result<Vec<u8>, CliError> {
 
 #[cfg(test)]
 mod tests {
-    use super::mac_to_string;
+    use super::*;
+
+    #[test]
+    fn test_parse_mac_str_ok() {
+        assert_eq!(
+            parse_mac_str("52:54:00:b0:52:d1").unwrap(),
+            vec![0x52, 0x54, 0x00, 0xb0, 0x52, 0xd1]
+        );
+    }
+
+    #[test]
+    fn test_parse_mac_str_invalid() {
+        assert!(parse_mac_str("zz:00:00:00:00:00").is_err());
+    }
+
+    #[test]
+    fn test_parse_mac_str_empty() {
+        assert!(parse_mac_str("").is_err());
+    }
 
     #[test]
     fn test_mac_to_string_ethernet() {


### PR DESCRIPTION
Supports all standard VLAN creation options:

```
  id               VLAN ID (required)
  protocol         802.1Q (default) or 802.1ad
  reorder_hdr      on/off
  gvrp             on/off
  mvrp             on/off
  loose_binding    on/off
  bridge_binding   on/off
  ingress-qos-map  from:to priority mapping
  egress-qos-map   from:to priority mapping
```
Integration test cases included.