### PR TITLE
support nlmon link type

### DIFF
--- a/src/ip/link/add.rs
+++ b/src/ip/link/add.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use futures_util::TryStreamExt;
 use iproute_rs::{CliError, parse_mac_str};
 use rtnetlink::{
-    LinkDummy, LinkMessageBuilder,
+    LinkDummy, LinkMessageBuilder, LinkNlmon,
     packet_route::link::{InfoKind, LinkMessage},
 };
 
@@ -44,6 +44,9 @@ impl LinkAddCommand {
         let nl_msg = match base_conf.iface_type {
             InfoKind::Dummy => {
                 base_conf.apply(LinkDummy::new(&base_conf.name))?
+            }
+            InfoKind::Nlmon => {
+                base_conf.apply(LinkNlmon::new(&base_conf.name))?
             }
             InfoKind::Vlan => {
                 base_conf.apply(base_conf.apply_vlan(&handle).await?)?

--- a/src/ip/link/tests/mod.rs
+++ b/src/ip/link/tests/mod.rs
@@ -5,5 +5,6 @@ mod bridge;
 mod color;
 mod dummy;
 mod loopback;
+mod nlmon;
 mod vlan;
 mod vxlan;

--- a/src/ip/link/tests/nlmon.rs
+++ b/src/ip/link/tests/nlmon.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+
+use crate::tests::{exec_cmd, ip_rs_exec_cmd};
+
+#[test]
+fn test_link_show_nlmon() {
+    let ifname = "tnlm0";
+
+    with_nlmon_iface(ifname, || {
+        let expected_output = exec_cmd(&["ip", "link", "show", ifname]);
+
+        let our_output = ip_rs_exec_cmd(&["link", "show", ifname]);
+
+        pretty_assertions::assert_eq!(expected_output, our_output);
+    })
+}
+
+#[test]
+fn test_link_detailed_show_nlmon() {
+    let ifname = "tnlm1";
+
+    with_nlmon_iface(ifname, || {
+        let expected_output = exec_cmd(&["ip", "-d", "link", "show", ifname]);
+
+        let our_output = ip_rs_exec_cmd(&["-d", "link", "show", ifname]);
+
+        pretty_assertions::assert_eq!(expected_output, our_output);
+    })
+}
+
+#[test]
+fn test_link_show_nlmon_json() {
+    let ifname = "tnlm2";
+
+    with_nlmon_iface(ifname, || {
+        let expected_output = exec_cmd(&["ip", "-j", "link", "show", ifname]);
+
+        let our_output = ip_rs_exec_cmd(&["-j", "link", "show", ifname]);
+
+        pretty_assertions::assert_eq!(expected_output, our_output);
+    })
+}
+
+#[test]
+fn test_link_detailed_show_nlmon_json() {
+    let ifname = "tnlm3";
+
+    with_nlmon_iface(ifname, || {
+        let expected_output =
+            exec_cmd(&["ip", "-d", "-j", "link", "show", ifname]);
+
+        let our_output = ip_rs_exec_cmd(&["-d", "-j", "link", "show", ifname]);
+
+        pretty_assertions::assert_eq!(expected_output, our_output);
+    })
+}
+
+fn with_nlmon_iface<T>(name: &str, test: T)
+where
+    T: FnOnce() + std::panic::UnwindSafe,
+{
+    ip_rs_exec_cmd(&["link", "add", name, "type", "nlmon"]);
+    exec_cmd(&["ip", "link", "set", name, "up"]);
+
+    let result = std::panic::catch_unwind(|| {
+        test();
+    });
+
+    // clean up
+    exec_cmd(&["ip", "link", "del", name]);
+    assert!(result.is_ok())
+}

--- a/src/ip/link/tests/vlan.rs
+++ b/src/ip/link/tests/vlan.rs
@@ -247,7 +247,15 @@ where
     let parent_name = format!("p{vlan_name}");
 
     // create parent dummy interface using ip-rs
-    ip_rs_exec_cmd(&["link", "add", &parent_name, "type", "dummy"]);
+    ip_rs_exec_cmd(&[
+        "link",
+        "add",
+        &parent_name,
+        "address",
+        "0e:d1:49:08:27:84",
+        "type",
+        "dummy",
+    ]);
     exec_cmd(&["ip", "link", "set", &parent_name, "up"]);
 
     let mut args = vec![


### PR DESCRIPTION
Introduce nlmon (Netlink monitor) interface support for both creation
and query. Usage:

  ip link add name NAME type nlmon

Integration test cases included.