### PR TITLE
fix test cleanup: ignore deletion errors and propagate panics properly

### DIFF
--- a/src/ip/link/tests/bond.rs
+++ b/src/ip/link/tests/bond.rs
@@ -82,7 +82,10 @@ where
     });
 
     // clean up
-    exec_cmd(&["ip", "link", "del", dummy_name]);
-    exec_cmd(&["ip", "link", "del", bond_name]);
-    assert!(result.is_ok())
+    let _ = exec_cmd(&["ip", "link", "del", dummy_name]);
+    let _ = exec_cmd(&["ip", "link", "del", bond_name]);
+
+    if let Err(e) = result {
+        std::panic::resume_unwind(e);
+    }
 }

--- a/src/ip/link/tests/bridge.rs
+++ b/src/ip/link/tests/bridge.rs
@@ -196,7 +196,10 @@ where
     });
 
     // clean up
-    exec_cmd(&["ip", "link", "del", dummy_name]);
-    exec_cmd(&["ip", "link", "del", br_name]);
-    assert!(result.is_ok())
+    let _ = exec_cmd(&["ip", "link", "del", dummy_name]);
+    let _ = exec_cmd(&["ip", "link", "del", br_name]);
+
+    if let Err(e) = result {
+        std::panic::resume_unwind(e);
+    }
 }

--- a/src/ip/link/tests/dummy.rs
+++ b/src/ip/link/tests/dummy.rs
@@ -75,6 +75,9 @@ where
     });
 
     // clean up
-    exec_cmd(&["ip", "link", "del", name]);
-    assert!(result.is_ok())
+    let _ = exec_cmd(&["ip", "link", "del", name]);
+
+    if let Err(e) = result {
+        std::panic::resume_unwind(e);
+    }
 }

--- a/src/ip/link/tests/nlmon.rs
+++ b/src/ip/link/tests/nlmon.rs
@@ -67,6 +67,9 @@ where
     });
 
     // clean up
-    exec_cmd(&["ip", "link", "del", name]);
-    assert!(result.is_ok())
+    let _ = exec_cmd(&["ip", "link", "del", name]);
+
+    if let Err(e) = result {
+        std::panic::resume_unwind(e);
+    }
 }

--- a/src/ip/link/tests/vlan.rs
+++ b/src/ip/link/tests/vlan.rs
@@ -281,7 +281,10 @@ where
     });
 
     // clean up
-    exec_cmd(&["ip", "link", "del", vlan_name]);
-    exec_cmd(&["ip", "link", "del", &parent_name]);
-    assert!(result.is_ok())
+    let _ = exec_cmd(&["ip", "link", "del", vlan_name]);
+    let _ = exec_cmd(&["ip", "link", "del", &parent_name]);
+
+    if let Err(e) = result {
+        std::panic::resume_unwind(e);
+    }
 }

--- a/src/ip/link/tests/vxlan.rs
+++ b/src/ip/link/tests/vxlan.rs
@@ -66,6 +66,9 @@ where
     });
 
     // clean up
-    exec_cmd(&["ip", "link", "del", vxlan_name]);
-    assert!(result.is_ok())
+    let _ = exec_cmd(&["ip", "link", "del", vxlan_name]);
+
+    if let Err(e) = result {
+        std::panic::resume_unwind(e);
+    }
 }


### PR DESCRIPTION
Replace assert-based cleanup with straightforward deletion calls and
explicit panic propagation via resume_unwind. This ensures that
cleanup failures don't mask test results, and panicked tests properly
unwind through the cleanup code.