### PR TITLE
support veth link type

### DIFF
--- a/src/ip/link/add.rs
+++ b/src/ip/link/add.rs
@@ -48,6 +48,7 @@ impl LinkAddCommand {
             InfoKind::Nlmon => {
                 base_conf.apply(LinkNlmon::new(&base_conf.name))?
             }
+            InfoKind::Veth => base_conf.apply(base_conf.apply_veth()?)?,
             InfoKind::Vlan => {
                 base_conf.apply(base_conf.apply_vlan(&handle).await?)?
             }

--- a/src/ip/link/ifaces/mod.rs
+++ b/src/ip/link/ifaces/mod.rs
@@ -2,5 +2,6 @@
 
 pub(super) mod bond;
 pub(super) mod bridge;
+pub(super) mod veth;
 pub(super) mod vlan;
 pub(super) mod vxlan;

--- a/src/ip/link/ifaces/veth.rs
+++ b/src/ip/link/ifaces/veth.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+
+use iproute_rs::CliError;
+use rtnetlink::{
+    LinkMessageBuilder, LinkVeth,
+    packet_route::link::{InfoVeth, LinkAttribute},
+};
+use serde::Serialize;
+
+use crate::link::LinkBaseConf;
+
+#[derive(Serialize)]
+pub(crate) struct CliLinkInfoDataVeth {
+    peer: String,
+}
+
+impl From<&InfoVeth> for CliLinkInfoDataVeth {
+    fn from(info: &InfoVeth) -> Self {
+        let mut peer = String::new();
+        if let InfoVeth::Peer(msg) = info {
+            for attr in &msg.attributes {
+                if let LinkAttribute::IfName(name) = attr {
+                    peer = name.clone();
+                    break;
+                }
+            }
+        }
+        Self { peer }
+    }
+}
+
+impl LinkBaseConf {
+    pub(crate) fn apply_veth(
+        &self,
+    ) -> Result<LinkMessageBuilder<LinkVeth>, CliError> {
+        let mut iter = self.iface_specific.iter();
+        match iter.next() {
+            Some(v) if v == "peer" => {}
+            Some(other) => {
+                return Err(CliError::from(format!(
+                    "veth expects peer argument, got {other}"
+                )));
+            }
+            None => {
+                return Err(CliError::from("veth requires peer argument"));
+            }
+        }
+        let Some(peer) = iter.next() else {
+            return Err(CliError::from("veth peer requires a value"));
+        };
+        Ok(LinkVeth::new(&self.name, peer))
+    }
+}
+
+impl std::fmt::Display for CliLinkInfoDataVeth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if !self.peer.is_empty() {
+            write!(f, "peer {}", self.peer)?;
+        }
+        Ok(())
+    }
+}

--- a/src/ip/link/link_info.rs
+++ b/src/ip/link/link_info.rs
@@ -7,6 +7,7 @@ use serde::Serialize;
 
 use super::ifaces::{
     bridge::{CliLinkInfoDataBridge, CliLinkInfoDataBridgePort},
+    veth::CliLinkInfoDataVeth,
     vlan::CliLinkInfoDataVlan,
     vxlan::CliLinkInfoDataVxlan,
 };
@@ -96,6 +97,7 @@ impl std::fmt::Display for CliLinkInfo {
 #[serde(untagged)]
 pub(crate) enum CliLinkInfoData {
     Vlan(Box<CliLinkInfoDataVlan>),
+    Veth(Box<CliLinkInfoDataVeth>),
     Bridge(Box<CliLinkInfoDataBridge>),
     Bond(Box<CliLinkInfoDataBond>),
     Vxlan(Box<CliLinkInfoDataVxlan>),
@@ -110,6 +112,7 @@ impl TryFrom<&InfoData> for CliLinkInfoData {
                 Ok(Self::Bridge(Box::new(v.as_slice().into())))
             }
             InfoData::Vlan(v) => Ok(Self::Vlan(Box::new(v.as_slice().into()))),
+            InfoData::Veth(v) => Ok(Self::Veth(Box::new(v.into()))),
             InfoData::Bond(v) => Ok(Self::Bond(Box::new(v.as_slice().into()))),
             InfoData::Vxlan(v) => {
                 Ok(Self::Vxlan(Box::new(v.as_slice().into())))
@@ -134,6 +137,7 @@ impl std::fmt::Display for CliLinkInfoData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             CliLinkInfoData::Vlan(v) => write!(f, "{v}"),
+            CliLinkInfoData::Veth(v) => write!(f, "{v}"),
             CliLinkInfoData::Bridge(v) => write!(f, "{v}"),
             CliLinkInfoData::Bond(v) => write!(f, "{v}"),
             CliLinkInfoData::Vxlan(v) => write!(f, "{v}"),

--- a/src/ip/link/tests/mod.rs
+++ b/src/ip/link/tests/mod.rs
@@ -6,5 +6,6 @@ mod color;
 mod dummy;
 mod loopback;
 mod nlmon;
+mod veth;
 mod vlan;
 mod vxlan;

--- a/src/ip/link/tests/veth.rs
+++ b/src/ip/link/tests/veth.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+
+use crate::tests::{exec_cmd, ip_rs_exec_cmd};
+
+#[test]
+fn test_link_show_veth() {
+    let ifname = "tveth0";
+    let peer = "tveth0_peer";
+
+    with_veth_iface(ifname, peer, || {
+        let expected_output = exec_cmd(&["ip", "link", "show", ifname]);
+
+        let our_output = ip_rs_exec_cmd(&["link", "show", ifname]);
+
+        pretty_assertions::assert_eq!(expected_output, our_output);
+    })
+}
+
+#[test]
+fn test_link_detailed_show_veth() {
+    let ifname = "tveth1";
+    let peer = "tveth1_peer";
+
+    with_veth_iface(ifname, peer, || {
+        let expected_output = exec_cmd(&["ip", "-d", "link", "show", ifname]);
+
+        let our_output = ip_rs_exec_cmd(&["-d", "link", "show", ifname]);
+
+        pretty_assertions::assert_eq!(expected_output, our_output);
+    })
+}
+
+#[test]
+fn test_link_show_veth_json() {
+    let ifname = "tveth2";
+    let peer = "tveth2_peer";
+
+    with_veth_iface(ifname, peer, || {
+        let expected_output = exec_cmd(&["ip", "-j", "link", "show", ifname]);
+
+        let our_output = ip_rs_exec_cmd(&["-j", "link", "show", ifname]);
+
+        pretty_assertions::assert_eq!(expected_output, our_output);
+    })
+}
+
+#[test]
+fn test_link_detailed_show_veth_json() {
+    let ifname = "tveth3";
+    let peer = "tveth3_peer";
+
+    with_veth_iface(ifname, peer, || {
+        let expected_output =
+            exec_cmd(&["ip", "-d", "-j", "link", "show", ifname]);
+
+        let our_output = ip_rs_exec_cmd(&["-d", "-j", "link", "show", ifname]);
+
+        pretty_assertions::assert_eq!(expected_output, our_output);
+    })
+}
+
+fn with_veth_iface<T>(name: &str, peer: &str, test: T)
+where
+    T: FnOnce() + std::panic::UnwindSafe,
+{
+    ip_rs_exec_cmd(&["link", "add", name, "type", "veth", "peer", peer]);
+    exec_cmd(&["ip", "link", "set", name, "up"]);
+    exec_cmd(&["ip", "link", "set", peer, "up"]);
+
+    let result = std::panic::catch_unwind(|| {
+        test();
+    });
+
+    // clean up (deleting veth removes both ends)
+    let _ = exec_cmd(&["ip", "link", "del", name]);
+
+    if let Err(e) = result {
+        std::panic::resume_unwind(e);
+    }
+}


### PR DESCRIPTION
Introduce veth (virtual ethernet) interface support for both creation
and query. Usage:

  ip link add NAME type veth peer PEER_NAME

The peer name is parsed from iface_specific. The display path extracts
the peer name from InfoVeth::Peer LinkMessage attributes and shows it
as 'peer <name>' in detailed output.

Integration tests cover basic show, detailed show, JSON show, and
detailed JSON show.