### PR TITLE
ip link add: support bond device creation

### DIFF
--- a/src/ip/link/add.rs
+++ b/src/ip/link/add.rs
@@ -52,6 +52,9 @@ impl LinkAddCommand {
             InfoKind::Vlan => {
                 base_conf.apply(base_conf.apply_vlan(&handle).await?)?
             }
+            InfoKind::Bond => {
+                base_conf.apply(base_conf.apply_bond(&handle).await?)?
+            }
             t => {
                 return Err(CliError::from(format!(
                     "Unsupported device type: {t}"

--- a/src/ip/link/ifaces/bond.rs
+++ b/src/ip/link/ifaces/bond.rs
@@ -1,11 +1,21 @@
 // SPDX-License-Identifier: MIT
 
-use iproute_rs::mac_to_string;
-use rtnetlink::packet_route::link::{
-    BondAdSelect, BondAllPortActive, BondArpValidate, BondLacpRate,
-    BondPortState, InfoBond, InfoBondPort, MiiStatus,
+use std::{
+    net::{Ipv4Addr, Ipv6Addr},
+    str::FromStr,
+};
+
+use iproute_rs::{CliError, mac_to_string, parse_mac_str};
+use rtnetlink::{
+    LinkBond, LinkMessageBuilder,
+    packet_route::link::{
+        BondAllPortActive, BondArpValidate, BondPortState, InfoBond,
+        InfoBondPort, MiiStatus,
+    },
 };
 use serde::Serialize;
+
+use crate::link::LinkBaseConf;
 
 #[derive(Serialize)]
 pub(crate) struct CliLinkInfoDataBond {
@@ -33,6 +43,16 @@ pub(crate) struct CliLinkInfoDataBond {
     coupled_control: bool,
     broadcast_neighbor: bool,
     ad_select: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ad_actor_sys_prio: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ad_user_port_key: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ad_actor_system: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    arp_ip_target: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ns_ip6_target: Option<Vec<String>>,
     tlb_dynamic_lb: u8,
 }
 
@@ -62,6 +82,11 @@ impl From<&[InfoBond]> for CliLinkInfoDataBond {
         let mut coupled_control = false;
         let mut broadcast_neighbor = false;
         let mut ad_select = String::new();
+        let mut ad_actor_sys_prio = None;
+        let mut ad_user_port_key = None;
+        let mut ad_actor_system = None;
+        let mut arp_ip_target = None;
+        let mut ns_ip6_target = None;
         let mut tlb_dynamic_lb = 0;
 
         for nla in info {
@@ -103,26 +128,28 @@ impl From<&[InfoBond]> for CliLinkInfoDataBond {
                 InfoBond::AdLacpActive(v) => {
                     ad_lacp_active = if *v { "on" } else { "off" }.to_string()
                 }
-                InfoBond::AdLacpRate(v) => {
-                    ad_lacp_rate = if matches!(*v, BondLacpRate::Fast) {
-                        "fast"
-                    } else {
-                        "slow"
-                    }
-                    .to_string()
+                InfoBond::AdLacpRate(v) => ad_lacp_rate = v.to_string(),
+                InfoBond::AdSelect(v) => ad_select = v.to_string(),
+                InfoBond::AdActorSysPrio(v) => {
+                    ad_actor_sys_prio = Some(*v);
                 }
-                InfoBond::AdSelect(v) => {
-                    ad_select = match *v {
-                        BondAdSelect::Stable => "stable",
-                        BondAdSelect::Bandwidth => "bandwidth",
-                        BondAdSelect::Count => "count",
-                        _ => "unknown",
-                    }
-                    .to_string()
+                InfoBond::AdUserPortKey(v) => {
+                    ad_user_port_key = Some(*v);
+                }
+                InfoBond::AdActorSystem(bytes) => {
+                    ad_actor_system = Some(mac_to_string(bytes));
                 }
                 InfoBond::TlbDynamicLb(v) => tlb_dynamic_lb = *v as u8,
                 InfoBond::CoupledControl(v) => coupled_control = *v,
                 InfoBond::BroadcastNeigh(v) => broadcast_neighbor = *v,
+                InfoBond::ArpIpTarget(addrs) => {
+                    arp_ip_target =
+                        Some(addrs.iter().map(|a| a.to_string()).collect());
+                }
+                InfoBond::NsIp6Target(addrs) => {
+                    ns_ip6_target =
+                        Some(addrs.iter().map(|a| a.to_string()).collect());
+                }
                 _ => (), /* println!("Remains {:?}", nla) */
             }
         }
@@ -150,6 +177,11 @@ impl From<&[InfoBond]> for CliLinkInfoDataBond {
             ad_lacp_active,
             ad_lacp_rate,
             ad_select,
+            ad_actor_sys_prio,
+            ad_user_port_key,
+            ad_actor_system,
+            arp_ip_target,
+            ns_ip6_target,
             tlb_dynamic_lb,
             coupled_control,
             broadcast_neighbor,
@@ -172,6 +204,16 @@ impl std::fmt::Display for CliLinkInfoDataBond {
         write!(f, " use_carrier {}", self.use_carrier)?;
         write!(f, " arp_interval {}", self.arp_interval)?;
         write!(f, " arp_missed_max {}", self.arp_missed_max)?;
+        if let Some(ref targets) = self.arp_ip_target
+            && !targets.is_empty()
+        {
+            write!(f, " arp_ip_target {}", targets.join(","))?;
+        }
+        if let Some(ref targets) = self.ns_ip6_target
+            && !targets.is_empty()
+        {
+            write!(f, " ns_ip6_target {}", targets.join(","))?;
+        }
         write!(f, " arp_validate {}", arp_validate)?;
         write!(f, " arp_all_targets {}", self.arp_all_targets)?;
         write!(f, " primary_reselect {}", self.primary_reselect)?;
@@ -188,6 +230,15 @@ impl std::fmt::Display for CliLinkInfoDataBond {
         write!(f, " coupled_control {}", on_off(self.coupled_control))?;
         write!(f, " broadcast_neighbor {}", on_off(self.broadcast_neighbor))?;
         write!(f, " ad_select {}", self.ad_select)?;
+        if let Some(v) = self.ad_actor_sys_prio {
+            write!(f, " ad_actor_sys_prio {v}")?;
+        }
+        if let Some(v) = self.ad_user_port_key {
+            write!(f, " ad_user_port_key {v}")?;
+        }
+        if let Some(ref v) = self.ad_actor_system {
+            write!(f, " ad_actor_system {v}")?;
+        }
         write!(f, " tlb_dynamic_lb {}", self.tlb_dynamic_lb)?;
 
         Ok(())
@@ -263,4 +314,245 @@ impl std::fmt::Display for CliLinkInfoDataBondPort {
 
         Ok(())
     }
+}
+
+impl LinkBaseConf {
+    pub(crate) async fn apply_bond(
+        &self,
+        handle: &rtnetlink::Handle,
+    ) -> Result<LinkMessageBuilder<LinkBond>, CliError> {
+        let mut builder = LinkBond::new(&self.name);
+
+        let mut iter = self.iface_specific.iter();
+        while let Some(key) = iter.next() {
+            let mut next_val = || {
+                iter.next().ok_or_else(|| {
+                    CliError::from(format!("bond {key} requires a value"))
+                })
+            };
+            match key.as_str() {
+                "mode" => {
+                    let v = next_val()?;
+                    builder = builder.mode(parse_from_str(v, "mode")?);
+                }
+                "active_slave" => {
+                    let v = next_val()?;
+                    let ifindex = self.get_ifindex_by_name(handle, v).await?;
+                    builder = builder.active_port(ifindex);
+                }
+                "miimon" => {
+                    let v = next_val()?;
+                    builder = builder.miimon(parse_u32(v, "miimon")?);
+                }
+                "updelay" => {
+                    let v = next_val()?;
+                    builder = builder.updelay(parse_u32(v, "updelay")?);
+                }
+                "downdelay" => {
+                    let v = next_val()?;
+                    builder = builder.downdelay(parse_u32(v, "downdelay")?);
+                }
+                "peer_notify_delay" => {
+                    let v = next_val()?;
+                    builder = builder
+                        .peer_notif_delay(parse_u32(v, "peer_notify_delay")?);
+                }
+                "use_carrier" => {
+                    let v = next_val()?;
+                    builder = builder.use_carrier(parse_on_off_01(v)?);
+                }
+                "arp_interval" => {
+                    let v = next_val()?;
+                    builder =
+                        builder.arp_interval(parse_u32(v, "arp_interval")?);
+                }
+                "arp_validate" => {
+                    let v = next_val()?;
+                    builder = builder
+                        .arp_validate(parse_from_str(v, "arp_validate")?);
+                }
+                "arp_all_targets" => {
+                    let v = next_val()?;
+                    builder = builder
+                        .arp_all_targets(parse_from_str(v, "arp_all_targets")?);
+                }
+                "arp_ip_target" => {
+                    let v = next_val()?;
+                    let addrs: Vec<Ipv4Addr> = v
+                        .split(',')
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                        .map(|s| {
+                            Ipv4Addr::from_str(s).map_err(|_| {
+                                CliError::from(format!(
+                                    "Invalid arp_ip_target address: {s}"
+                                ))
+                            })
+                        })
+                        .collect::<Result<_, _>>()?;
+                    builder = builder.arp_ip_target(addrs);
+                }
+                "ns_ip6_target" => {
+                    let v = next_val()?;
+                    let addrs: Vec<Ipv6Addr> = v
+                        .split(',')
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                        .map(|s| {
+                            Ipv6Addr::from_str(s).map_err(|_| {
+                                CliError::from(format!(
+                                    "Invalid ns_ip6_target address: {s}"
+                                ))
+                            })
+                        })
+                        .collect::<Result<_, _>>()?;
+                    builder = builder.ns_ip6_target(addrs);
+                }
+                "primary" => {
+                    let v = next_val()?;
+                    let ifindex = self.get_ifindex_by_name(handle, v).await?;
+                    builder = builder.primary(ifindex);
+                }
+                "primary_reselect" => {
+                    let v = next_val()?;
+                    builder = builder.primary_reselect(parse_from_str(
+                        v,
+                        "primary_reselect",
+                    )?);
+                }
+                "fail_over_mac" => {
+                    let v = next_val()?;
+                    builder = builder
+                        .fail_over_mac(parse_from_str(v, "fail_over_mac")?);
+                }
+                "xmit_hash_policy" => {
+                    let v = next_val()?;
+                    builder = builder.xmit_hash_policy(parse_from_str(
+                        v,
+                        "xmit_hash_policy",
+                    )?);
+                }
+                "resend_igmp" => {
+                    let v = next_val()?;
+                    builder = builder.resend_igmp(parse_u32(v, "resend_igmp")?);
+                }
+                "num_grat_arp" | "num_unsol_na" => {
+                    let v = next_val()?;
+                    builder = builder.num_peer_notif(parse_u8(v, key)?);
+                }
+                "all_slaves_active" => {
+                    let v = next_val()?;
+                    builder = builder.all_ports_active(parse_from_str(
+                        v,
+                        "all_slaves_active",
+                    )?);
+                }
+                "min_links" => {
+                    let v = next_val()?;
+                    builder = builder.min_links(parse_u32(v, "min_links")?);
+                }
+                "lp_interval" => {
+                    let v = next_val()?;
+                    builder = builder.lp_interval(parse_u32(v, "lp_interval")?);
+                }
+                "packets_per_slave" => {
+                    let v = next_val()?;
+                    builder = builder.packets_per_port(parse_u32(v, key)?);
+                }
+                "tlb_dynamic_lb" => {
+                    let v = next_val()?;
+                    builder = builder.tlb_dynamic_lb(parse_on_off_01(v)?);
+                }
+                "lacp_rate" => {
+                    let v = next_val()?;
+                    builder =
+                        builder.ad_lacp_rate(parse_from_str(v, "lacp_rate")?);
+                }
+                "lacp_active" | "ad_lacp_active" => {
+                    let v = next_val()?;
+                    builder = builder.ad_lacp_active(parse_on_off_01(v)?);
+                }
+                "coupled_control" => {
+                    let v = next_val()?;
+                    builder = builder.append_info_data(
+                        InfoBond::CoupledControl(parse_on_off_01(v)?),
+                    );
+                }
+                "broadcast_neighbor" => {
+                    let v = next_val()?;
+                    builder = builder.append_info_data(
+                        InfoBond::BroadcastNeigh(parse_on_off_01(v)?),
+                    );
+                }
+                "ad_select" => {
+                    let v = next_val()?;
+                    builder =
+                        builder.ad_select(parse_from_str(v, "ad_select")?);
+                }
+                "ad_user_port_key" => {
+                    let v = next_val()?;
+                    builder = builder
+                        .ad_user_port_key(parse_u16(v, "ad_user_port_key")?);
+                }
+                "ad_actor_sys_prio" => {
+                    let v = next_val()?;
+                    builder = builder
+                        .ad_actor_sys_prio(parse_u16(v, "ad_actor_sys_prio")?);
+                }
+                "ad_actor_system" => {
+                    let v = next_val()?;
+                    let mac: [u8; 6] =
+                        parse_mac_str(v)?.try_into().map_err(|_| {
+                            CliError::from(format!(
+                                "Invalid ad_actor_system MAC: {v}"
+                            ))
+                        })?;
+                    builder = builder.ad_actor_system(mac);
+                }
+                "arp_missed_max" => {
+                    let v = next_val()?;
+                    builder =
+                        builder.missed_max(parse_u8(v, "arp_missed_max")?);
+                }
+                _ => {
+                    return Err(CliError::from(format!(
+                        "Unknown bond argument: {key}"
+                    )));
+                }
+            }
+        }
+
+        Ok(builder)
+    }
+}
+
+fn parse_on_off_01(s: &str) -> Result<bool, CliError> {
+    match s {
+        "on" | "1" => Ok(true),
+        "off" | "0" => Ok(false),
+        _ => Err(CliError::from(format!("expected on/off or 0/1, got {s}"))),
+    }
+}
+
+fn parse_u32(s: &str, name: &str) -> Result<u32, CliError> {
+    s.parse::<u32>()
+        .map_err(|_| CliError::from(format!("Invalid {name} value: {s}")))
+}
+
+fn parse_u8(s: &str, name: &str) -> Result<u8, CliError> {
+    s.parse::<u8>()
+        .map_err(|_| CliError::from(format!("Invalid {name} value: {s}")))
+}
+
+fn parse_u16(s: &str, name: &str) -> Result<u16, CliError> {
+    s.parse::<u16>()
+        .map_err(|_| CliError::from(format!("Invalid {name} value: {s}")))
+}
+
+fn parse_from_str<T: FromStr>(s: &str, name: &str) -> Result<T, CliError>
+where
+    T::Err: std::fmt::Display,
+{
+    s.parse::<T>()
+        .map_err(|e| CliError::from(format!("Invalid {name} value: {e}")))
 }

--- a/src/ip/link/tests/bond.rs
+++ b/src/ip/link/tests/bond.rs
@@ -33,6 +33,110 @@ fn test_link_detailed_show_json_bond_port() {
     })
 }
 
+#[test]
+fn test_link_create_bond_default() {
+    with_bond_creation_iface(&[], |ns| {
+        ns.assert_eq_output(&["-d", "link", "show", BOND_NAME]);
+    });
+}
+
+#[test]
+fn test_link_create_bond_mode() {
+    with_bond_creation_iface(&["mode", "active-backup"], |ns| {
+        let outputs = ns.assert_eq_output(&["-d", "link", "show", BOND_NAME]);
+        assert!(outputs.expected.contains("mode active-backup"));
+    });
+}
+
+#[test]
+fn test_link_create_bond_miimon() {
+    with_bond_creation_iface(&["miimon", "200"], |ns| {
+        let outputs = ns.assert_eq_output(&["-d", "link", "show", BOND_NAME]);
+        assert!(outputs.expected.contains("miimon 200"));
+    });
+}
+
+#[test]
+fn test_link_create_bond_arp_interval() {
+    with_bond_creation_iface(
+        &["arp_interval", "500", "arp_validate", "active"],
+        |ns| {
+            let outputs =
+                ns.assert_eq_output(&["-d", "link", "show", BOND_NAME]);
+            assert!(outputs.expected.contains("arp_interval 500"));
+            assert!(outputs.expected.contains("arp_validate active"));
+        },
+    );
+}
+
+#[test]
+fn test_link_create_bond_xmit_hash_policy() {
+    with_bond_creation_iface(&["xmit_hash_policy", "layer3+4"], |ns| {
+        let outputs = ns.assert_eq_output(&["-d", "link", "show", BOND_NAME]);
+        assert!(outputs.expected.contains("xmit_hash_policy layer3+4"));
+    });
+}
+
+#[test]
+fn test_link_create_bond_balance_rr_multiopts() {
+    with_bond_creation_iface(
+        &[
+            "mode",
+            "balance-rr",
+            "miimon",
+            "200",
+            "xmit_hash_policy",
+            "layer3+4",
+            "min_links",
+            "2",
+            "arp_missed_max",
+            "3",
+            "num_grat_arp",
+            "5",
+            "resend_igmp",
+            "3",
+            "primary_reselect",
+            "better",
+            "fail_over_mac",
+            "active",
+        ],
+        |ns| {
+            let outputs =
+                ns.assert_eq_output(&["-d", "link", "show", BOND_NAME]);
+            assert!(outputs.expected.contains("mode balance-rr"));
+            assert!(outputs.expected.contains("miimon 200"));
+            assert!(outputs.expected.contains("xmit_hash_policy layer3+4"));
+            assert!(outputs.expected.contains("min_links 2"));
+            assert!(outputs.expected.contains("arp_missed_max 3"));
+            assert!(outputs.expected.contains("num_grat_arp 5"));
+            assert!(outputs.expected.contains("resend_igmp 3"));
+            assert!(outputs.expected.contains("primary_reselect better"));
+            assert!(outputs.expected.contains("fail_over_mac active"));
+        },
+    );
+}
+
+#[test]
+fn test_link_create_bond_802_3ad() {
+    with_bond_creation_iface(
+        &[
+            "mode",
+            "802.3ad",
+            "ad_select",
+            "bandwidth",
+            "min_links",
+            "2",
+        ],
+        |ns| {
+            let outputs =
+                ns.assert_eq_output(&["-d", "link", "show", BOND_NAME]);
+            assert!(outputs.expected.contains("mode 802.3ad"));
+            assert!(outputs.expected.contains("ad_select bandwidth"));
+            assert!(outputs.expected.contains("min_links 2"));
+        },
+    );
+}
+
 fn with_bond_iface<T>(test: T)
 where
     T: FnOnce(&NetnsGuard),
@@ -45,6 +149,21 @@ where
         ]);
 
         ns.exec_cmd(&["ip", "link", "set", DUMMY_NAME, "up"]);
+        ns.exec_cmd(&["ip", "link", "set", BOND_NAME, "up"]);
+
+        test(ns);
+    })
+}
+
+fn with_bond_creation_iface<T>(opts: &[&str], test: T)
+where
+    T: FnOnce(&NetnsGuard),
+{
+    with_netns(|ns| {
+        let mut args = vec!["link", "add", BOND_NAME, "type", "bond"];
+        args.extend_from_slice(opts);
+
+        ns.ip_rs_exec_cmd(&args);
         ns.exec_cmd(&["ip", "link", "set", BOND_NAME, "up"]);
 
         test(ns);


### PR DESCRIPTION
Introduced support `ip link add NAME type bond [OPTIONS]`.
Accepts all bond options identical to iproute2:

  mode, active_slave, miimon, updelay, downdelay,
  peer_notify_delay, use_carrier, arp_interval, arp_validate,
  arp_all_targets, arp_ip_target, ns_ip6_target, primary,
  primary_reselect, fail_over_mac, xmit_hash_policy,
  resend_igmp, num_grat_arp/num_unsol_na, all_slaves_active,
  min_links, lp_interval, packets_per_slave, tlb_dynamic_lb,
  lacp_rate, lacp_active/ad_lacp_active, coupled_control,
  broadcast_neighbor, ad_select, ad_user_port_key,
  ad_actor_sys_prio, ad_actor_system, arp_missed_max

Uses netlink-packet-route FromStr/Display for all bond options
(BondMode, BondArpValidate, BondArpAllTargets, BondPrimaryReselect,
BondFailOverMac, BondAdSelect, BondXmitHashPolicy) via a generic
parse_from_str helper.

Added arp_ip_target, ns_ip6_target, ad_actor_sys_prio,
ad_user_port_key, ad_actor_system display fields.

Includes 7 integration tests for bond creation with various
option combinations.