### PR TITLE
ip link: add hsr type support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,5 @@ tokio = { version = "1.30", features = ["rt", "net", "time", "macros"] }
 pretty_assertions = "1.4.1"
 rand = "0.10.0"
 
-[patch.crates-io.rtnetlink]
-git = "https://github.com/rust-netlink/rtnetlink"
-
 [patch.crates-io.netlink-packet-route]
 git = "https://github.com/rust-netlink/netlink-packet-route"

--- a/src/ip/link/add.rs
+++ b/src/ip/link/add.rs
@@ -56,6 +56,9 @@ impl LinkAddCommand {
                 base_conf.apply(base_conf.apply_bond(&handle).await?)?
             }
             InfoKind::Bridge => base_conf.apply(base_conf.apply_bridge()?)?,
+            InfoKind::Hsr => {
+                base_conf.apply(base_conf.apply_hsr(&handle).await?)?
+            }
             t => {
                 return Err(CliError::from(format!(
                     "Unsupported device type: {t}"

--- a/src/ip/link/detail.rs
+++ b/src/ip/link/detail.rs
@@ -140,12 +140,9 @@ impl CliLinkInfoDetail {
         self.inet6_addr_gen_mode = String::new();
     }
 
-    pub(crate) fn resolve_vxlan_link(
-        &mut self,
-        index_2_name: &HashMap<u32, String>,
-    ) {
+    pub(crate) fn resolve_link(&mut self, index_2_name: &HashMap<u32, String>) {
         if let Some(ref mut linkinfo) = self.linkinfo {
-            linkinfo.resolve_vxlan_link(index_2_name);
+            linkinfo.resolve_link(index_2_name);
         }
     }
 }

--- a/src/ip/link/ifaces/hsr.rs
+++ b/src/ip/link/ifaces/hsr.rs
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: MIT
+
+use std::collections::HashMap;
+
+use iproute_rs::{CliError, mac_to_string};
+use rtnetlink::{
+    LinkHsr, LinkMessageBuilder,
+    packet_route::link::{HsrProtocol, InfoHsr},
+};
+use serde::Serialize;
+
+use super::parse::parse_u8;
+use crate::link::LinkBaseConf;
+
+#[derive(Serialize)]
+pub(crate) struct CliLinkInfoDataHsr {
+    #[serde(skip)]
+    port1_index: Option<u32>,
+    #[serde(skip)]
+    port2_index: Option<u32>,
+    #[serde(skip)]
+    interlink_index: Option<u32>,
+    #[serde(rename = "slave1", skip_serializing_if = "Option::is_none")]
+    port1: Option<String>,
+    #[serde(rename = "slave2", skip_serializing_if = "Option::is_none")]
+    port2: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    interlink: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "seq_nr")]
+    sequence: Option<u16>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "supervision_addr"
+    )]
+    supervision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    proto: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    version: Option<u8>,
+}
+
+impl CliLinkInfoDataHsr {
+    pub(crate) fn resolve_link(&mut self, index_2_name: &HashMap<u32, String>) {
+        let resolve = |idx: u32| {
+            index_2_name
+                .get(&idx)
+                .cloned()
+                .unwrap_or_else(|| format!("if{idx}"))
+        };
+        self.port1 = self.port1_index.map(resolve);
+        self.port2 = self.port2_index.map(resolve);
+        self.interlink = self.interlink_index.map(resolve);
+    }
+}
+
+impl From<&[InfoHsr]> for CliLinkInfoDataHsr {
+    fn from(info: &[InfoHsr]) -> Self {
+        let mut port1_index = None;
+        let mut port2_index = None;
+        let mut interlink_index = None;
+        let mut sequence = None;
+        let mut supervision = None;
+        let mut proto = None;
+        let mut version = None;
+
+        for nla in info {
+            match nla {
+                InfoHsr::Port1(v) => port1_index = Some(*v),
+                InfoHsr::Port2(v) => port2_index = Some(*v),
+                InfoHsr::Interlink(v) => interlink_index = Some(*v),
+                InfoHsr::SeqNr(v) => sequence = Some(*v),
+                InfoHsr::SupervisionAddr(v) => {
+                    supervision = Some(mac_to_string(v))
+                }
+                InfoHsr::Protocol(HsrProtocol::Hsr) => proto = Some(0),
+                InfoHsr::Protocol(HsrProtocol::Prp) => proto = Some(1),
+                InfoHsr::Protocol(HsrProtocol::Other(v)) => proto = Some(*v),
+                InfoHsr::Version(v) => version = Some(*v),
+                _ => (),
+            }
+        }
+
+        Self {
+            port1_index,
+            port2_index,
+            interlink_index,
+            port1: None,
+            port2: None,
+            interlink: None,
+            sequence,
+            supervision,
+            proto,
+            version,
+        }
+    }
+}
+
+impl std::fmt::Display for CliLinkInfoDataHsr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(v) = &self.port1 {
+            write!(f, "slave1 {v}")?;
+        }
+        if let Some(v) = &self.port2 {
+            write!(f, " slave2 {v}")?;
+        }
+        if let Some(v) = &self.interlink {
+            write!(f, " interlink {v}")?;
+        }
+        if let Some(v) = self.sequence {
+            write!(f, " sequence {v}")?;
+        }
+        if let Some(v) = &self.supervision {
+            write!(f, " supervision {v}")?;
+        }
+        if let Some(v) = self.proto {
+            write!(f, " proto {v}")?;
+        }
+        if let Some(v) = self.version {
+            write!(f, " version {v}")?;
+        }
+        Ok(())
+    }
+}
+
+impl LinkBaseConf {
+    pub(crate) async fn apply_hsr(
+        &self,
+        handle: &rtnetlink::Handle,
+    ) -> Result<LinkMessageBuilder<LinkHsr>, CliError> {
+        let mut builder = LinkHsr::new(&self.name);
+        let mut has_port1 = false;
+        let mut has_port2 = false;
+
+        let mut iter = self.iface_specific.iter();
+        while let Some(key) = iter.next() {
+            let mut next_val = || {
+                iter.next().ok_or_else(|| {
+                    CliError::from(format!("hsr {key} requires a value"))
+                })
+            };
+            match key.as_str() {
+                "slave1" => {
+                    let v = next_val()?;
+                    let ifindex = self.get_ifindex_by_name(handle, v).await?;
+                    builder = builder.port1(ifindex);
+                    has_port1 = true;
+                }
+                "slave2" => {
+                    let v = next_val()?;
+                    let ifindex = self.get_ifindex_by_name(handle, v).await?;
+                    builder = builder.port2(ifindex);
+                    has_port2 = true;
+                }
+                "interlink" => {
+                    let v = next_val()?;
+                    let ifindex = self.get_ifindex_by_name(handle, v).await?;
+                    builder = builder.interlink(ifindex);
+                }
+                "supervision" => {
+                    let v = next_val()?;
+                    builder = builder.supervision(parse_u8(v, "supervision")?);
+                }
+                "version" => {
+                    let v = next_val()?;
+                    builder = builder.version(parse_u8(v, "version")?);
+                }
+                "proto" => {
+                    let v = next_val()?;
+                    let proto: u8 = parse_u8(v, "proto")?;
+                    builder = builder.protocol(proto.into());
+                }
+                _ => {
+                    return Err(CliError::from(format!(
+                        "Unknown hsr argument: {key}"
+                    )));
+                }
+            }
+        }
+
+        if !has_port1 || !has_port2 {
+            return Err(CliError::from(
+                "hsr requires slave1 and slave2 arguments",
+            ));
+        }
+
+        Ok(builder)
+    }
+}

--- a/src/ip/link/ifaces/mod.rs
+++ b/src/ip/link/ifaces/mod.rs
@@ -2,6 +2,7 @@
 
 pub(super) mod bond;
 pub(super) mod bridge;
+pub(super) mod hsr;
 pub(super) mod parse;
 pub(super) mod veth;
 pub(super) mod vlan;

--- a/src/ip/link/link_info.rs
+++ b/src/ip/link/link_info.rs
@@ -7,6 +7,7 @@ use serde::Serialize;
 
 use super::ifaces::{
     bridge::{CliLinkInfoDataBridge, CliLinkInfoDataBridgePort},
+    hsr::CliLinkInfoDataHsr,
     veth::CliLinkInfoDataVeth,
     vlan::CliLinkInfoDataVlan,
     vxlan::CliLinkInfoDataVxlan,
@@ -65,12 +66,9 @@ impl TryFrom<&[LinkInfo]> for CliLinkInfo {
 }
 
 impl CliLinkInfo {
-    pub(crate) fn resolve_vxlan_link(
-        &mut self,
-        index_2_name: &HashMap<u32, String>,
-    ) {
+    pub(crate) fn resolve_link(&mut self, index_2_name: &HashMap<u32, String>) {
         if let Some(ref mut data) = self.info_data {
-            data.resolve_vxlan_link(index_2_name);
+            data.resolve_link(index_2_name);
         }
     }
 }
@@ -101,6 +99,7 @@ pub(crate) enum CliLinkInfoData {
     Bridge(Box<CliLinkInfoDataBridge>),
     Bond(Box<CliLinkInfoDataBond>),
     Vxlan(Box<CliLinkInfoDataVxlan>),
+    Hsr(Box<CliLinkInfoDataHsr>),
 }
 
 impl TryFrom<&InfoData> for CliLinkInfoData {
@@ -117,18 +116,18 @@ impl TryFrom<&InfoData> for CliLinkInfoData {
             InfoData::Vxlan(v) => {
                 Ok(Self::Vxlan(Box::new(v.as_slice().into())))
             }
+            InfoData::Hsr(v) => Ok(Self::Hsr(Box::new(v.as_slice().into()))),
             _ => Err(()),
         }
     }
 }
 
 impl CliLinkInfoData {
-    pub(crate) fn resolve_vxlan_link(
-        &mut self,
-        index_2_name: &HashMap<u32, String>,
-    ) {
-        if let Self::Vxlan(vxlan) = self {
-            vxlan.resolve_link(index_2_name);
+    pub(crate) fn resolve_link(&mut self, index_2_name: &HashMap<u32, String>) {
+        match self {
+            Self::Vxlan(vxlan) => vxlan.resolve_link(index_2_name),
+            Self::Hsr(hsr) => hsr.resolve_link(index_2_name),
+            _ => (),
         }
     }
 }
@@ -141,6 +140,7 @@ impl std::fmt::Display for CliLinkInfoData {
             CliLinkInfoData::Bridge(v) => write!(f, "{v}"),
             CliLinkInfoData::Bond(v) => write!(f, "{v}"),
             CliLinkInfoData::Vxlan(v) => write!(f, "{v}"),
+            CliLinkInfoData::Hsr(v) => write!(f, "{v}"),
         }
     }
 }

--- a/src/ip/link/show.rs
+++ b/src/ip/link/show.rs
@@ -387,9 +387,9 @@ fn resolve_controller_and_link_names(links: &mut [CliLinkInfo]) {
             }
         }
 
-        // Resolve VxLAN link ifindex to interface name
+        // Resolve link ifindex (VxLAN, HSR, etc.) to interface name
         if let Some(ref mut details) = link.details {
-            details.resolve_vxlan_link(&index_2_name);
+            details.resolve_link(&index_2_name);
         }
     }
 }

--- a/src/ip/link/tests/hsr.rs
+++ b/src/ip/link/tests/hsr.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+
+use crate::tests::{NetnsGuard, with_netns};
+
+const HSR_NAME: &str = "thsr";
+const PORT1_NAME: &str = "thsr-p1";
+const PORT2_NAME: &str = "thsr-p2";
+
+/// Kernel maintains `hsr->sequence_nr` starting at `USHRT_MAX - 1024` (64511)
+/// and increments it on every sent data or supervision frame (supervision
+/// frames fire every 2 seconds). Between two `ip link show` calls the value
+/// advances, making direct comparison flaky — we zero it out for testing.
+fn normalize_seq(mut s: String) -> String {
+    for target in [" sequence ", "\"seq_nr\":"] {
+        let mut result = String::new();
+        let mut remaining = s.as_str();
+        while let Some(pos) = remaining.find(target) {
+            result.push_str(&remaining[..=pos + target.len() - 1]);
+            remaining = &remaining[pos + target.len()..];
+            let num_len =
+                remaining.chars().take_while(|c| c.is_ascii_digit()).count();
+            result.push('0');
+            remaining = &remaining[num_len..];
+        }
+        result.push_str(remaining);
+        s = result;
+    }
+    s
+}
+
+#[test]
+fn test_hsr_create_and_show_default() {
+    with_hsr_iface(&[], |ns| {
+        ns.assert_eq_output_map(
+            &["-d", "link", "show", HSR_NAME],
+            normalize_seq,
+        );
+    });
+}
+
+#[test]
+fn test_hsr_create_and_show_with_options() {
+    with_hsr_iface(&["supervision", "42", "version", "1"], |ns| {
+        ns.assert_eq_output_map(
+            &["-d", "link", "show", HSR_NAME],
+            normalize_seq,
+        );
+    });
+}
+
+#[test]
+fn test_hsr_create_and_show_json() {
+    with_hsr_iface(&[], |ns| {
+        ns.assert_eq_output_map(
+            &["-d", "-j", "link", "show", HSR_NAME],
+            normalize_seq,
+        );
+    });
+}
+
+fn with_hsr_iface<T>(opts: &[&str], test: T)
+where
+    T: FnOnce(&NetnsGuard),
+{
+    with_netns(|ns| {
+        // Create two dummy interfaces as slaves
+        ns.exec_cmd(&["ip", "link", "add", PORT1_NAME, "type", "dummy"]);
+        ns.exec_cmd(&["ip", "link", "add", PORT2_NAME, "type", "dummy"]);
+        ns.exec_cmd(&["ip", "link", "set", PORT1_NAME, "up"]);
+        ns.exec_cmd(&["ip", "link", "set", PORT2_NAME, "up"]);
+
+        // Create HSR interface via ip-rs
+        let mut args = vec![
+            "link", "add", HSR_NAME, "type", "hsr", "slave1", PORT1_NAME,
+            "slave2", PORT2_NAME,
+        ];
+        args.extend_from_slice(opts);
+
+        ns.ip_rs_exec_cmd(&args);
+        ns.exec_cmd(&["ip", "link", "set", HSR_NAME, "up"]);
+
+        test(ns);
+    });
+}

--- a/src/ip/link/tests/mod.rs
+++ b/src/ip/link/tests/mod.rs
@@ -4,6 +4,7 @@ mod bond;
 mod bridge;
 mod color;
 mod dummy;
+mod hsr;
 mod loopback;
 mod nlmon;
 mod veth;


### PR DESCRIPTION
Introduced `ip link add type hsr` command and `ip link show hsr`
display.

Supported arguments: slave1 (required), slave2 (required), interlink,
supervision, version, proto.

Integration test case included to verify creation and detailed show
output match iproute2.