### PR TITLE
link: add netkit interface type support

### DIFF
--- a/src/ip/link/add.rs
+++ b/src/ip/link/add.rs
@@ -59,6 +59,7 @@ impl LinkAddCommand {
             InfoKind::Hsr => {
                 base_conf.apply(base_conf.apply_hsr(&handle).await?)?
             }
+            InfoKind::Netkit => base_conf.apply(base_conf.apply_netkit()?)?,
             InfoKind::IpIp => {
                 base_conf.apply(base_conf.apply_iptun(&handle).await?)?
             }

--- a/src/ip/link/ifaces/mod.rs
+++ b/src/ip/link/ifaces/mod.rs
@@ -4,6 +4,7 @@ pub(super) mod bond;
 pub(super) mod bridge;
 pub(super) mod hsr;
 pub(super) mod iptun;
+pub(super) mod netkit;
 pub(super) mod parse;
 pub(super) mod veth;
 pub(super) mod vlan;

--- a/src/ip/link/ifaces/netkit.rs
+++ b/src/ip/link/ifaces/netkit.rs
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: MIT
+
+use iproute_rs::CliError;
+use rtnetlink::{
+    LinkMessageBuilder, LinkNetkit,
+    packet_route::link::{InfoNetkit, NetkitMode, NetkitPolicy, NetkitScrub},
+};
+use serde::Serialize;
+
+use crate::link::LinkBaseConf;
+
+#[derive(Serialize)]
+pub(crate) struct CliLinkInfoDataNetkit {
+    mode: String,
+    #[serde(rename = "type")]
+    typ: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    policy: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    peer_policy: Option<String>,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    scrub: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    peer_scrub: String,
+}
+
+impl From<&[InfoNetkit]> for CliLinkInfoDataNetkit {
+    fn from(info: &[InfoNetkit]) -> Self {
+        let mut mode = String::new();
+        let mut typ = String::new();
+        let mut policy = None;
+        let mut peer_policy = None;
+        let mut scrub = String::new();
+        let mut peer_scrub = String::new();
+        for nla in info {
+            match nla {
+                InfoNetkit::Mode(m) => {
+                    mode = match m {
+                        NetkitMode::L2 => "l2".to_string(),
+                        NetkitMode::L3 => "l3".to_string(),
+                        _ => format!("{m:?}"),
+                    };
+                }
+                InfoNetkit::Primary(v) => {
+                    typ = if *v {
+                        "primary".to_string()
+                    } else {
+                        "peer".to_string()
+                    };
+                }
+                InfoNetkit::Policy(p) => {
+                    policy = Some(match p {
+                        NetkitPolicy::Pass => "forward".to_string(),
+                        NetkitPolicy::Drop => "blackhole".to_string(),
+                        _ => format!("{p:?}"),
+                    });
+                }
+                InfoNetkit::PeerPolicy(p) => {
+                    peer_policy = Some(match p {
+                        NetkitPolicy::Pass => "forward".to_string(),
+                        NetkitPolicy::Drop => "blackhole".to_string(),
+                        _ => format!("{p:?}"),
+                    });
+                }
+                InfoNetkit::Scrub(s) => {
+                    scrub = match s {
+                        NetkitScrub::None => "none".to_string(),
+                        NetkitScrub::Default => "default".to_string(),
+                        _ => format!("{s:?}"),
+                    };
+                }
+                InfoNetkit::PeerScrub(s) => {
+                    peer_scrub = match s {
+                        NetkitScrub::None => "none".to_string(),
+                        NetkitScrub::Default => "default".to_string(),
+                        _ => format!("{s:?}"),
+                    };
+                }
+                _ => (),
+            }
+        }
+
+        Self {
+            mode,
+            typ,
+            policy,
+            peer_policy,
+            scrub,
+            peer_scrub,
+        }
+    }
+}
+
+impl LinkBaseConf {
+    pub(crate) fn apply_netkit(
+        &self,
+    ) -> Result<LinkMessageBuilder<LinkNetkit>, CliError> {
+        let mut mode = NetkitMode::L3;
+        let mut policy = None;
+        let mut peer_policy = None;
+        let mut scrub = None;
+        let mut peer_scrub = None;
+        let mut peer_name = None;
+        let mut seen_peer = false;
+
+        let mut iter = self.iface_specific.iter().peekable();
+        while let Some(key) = iter.next() {
+            match key.as_str() {
+                "mode" => {
+                    let Some(v) = iter.next() else {
+                        return Err(CliError::from(
+                            "netkit mode requires a value",
+                        ));
+                    };
+                    mode = match v.as_str() {
+                        "l3" => NetkitMode::L3,
+                        "l2" => NetkitMode::L2,
+                        _ => {
+                            return Err(CliError::from(format!(
+                                "netkit mode must be l3 or l2, got {v}"
+                            )));
+                        }
+                    };
+                }
+                "forward" | "blackhole" => {
+                    let p = match key.as_str() {
+                        "forward" => NetkitPolicy::Pass,
+                        _ => NetkitPolicy::Drop,
+                    };
+                    if seen_peer {
+                        peer_policy = Some(p);
+                    } else {
+                        policy = Some(p);
+                    }
+                }
+                "peer" => {
+                    seen_peer = true;
+                }
+                "name" if seen_peer => {
+                    let Some(v) = iter.next() else {
+                        return Err(CliError::from(
+                            "netkit peer name requires a value",
+                        ));
+                    };
+                    peer_name = Some(v.clone());
+                }
+                "scrub" => {
+                    let Some(v) = iter.next() else {
+                        return Err(CliError::from(
+                            "netkit scrub requires a value",
+                        ));
+                    };
+                    let s = match v.as_str() {
+                        "default" => NetkitScrub::Default,
+                        "none" => NetkitScrub::None,
+                        _ => {
+                            return Err(CliError::from(format!(
+                                "netkit scrub must be default or none, got {v}"
+                            )));
+                        }
+                    };
+                    if seen_peer {
+                        peer_scrub = Some(s);
+                    } else {
+                        scrub = Some(s);
+                    }
+                }
+                _ if seen_peer && peer_name.is_none() => {
+                    peer_name = Some(key.clone());
+                }
+                _ => {
+                    return Err(CliError::from(format!(
+                        "Unknown netkit argument: {key}"
+                    )));
+                }
+            }
+        }
+
+        let mut builder = LinkMessageBuilder::<LinkNetkit>::new_with_info_kind(
+            rtnetlink::packet_route::link::InfoKind::Netkit,
+        )
+        .name(self.name.clone())
+        .mode(mode);
+
+        if let Some(ref name) = peer_name {
+            builder = builder.peer(name);
+        }
+
+        if let Some(p) = policy {
+            builder = builder.policy(p);
+        }
+
+        if let Some(p) = peer_policy {
+            builder = builder.peer_policy(p);
+        }
+
+        if let Some(s) = scrub {
+            builder = builder.scrub(s);
+        }
+
+        if let Some(s) = peer_scrub {
+            builder = builder.peer_scrub(s);
+        }
+
+        Ok(builder)
+    }
+}
+
+impl std::fmt::Display for CliLinkInfoDataNetkit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "mode {} type {}", self.mode, self.typ)?;
+        if let Some(ref policy) = self.policy {
+            write!(f, " policy {policy}")?;
+        }
+        if let Some(ref peer_policy) = self.peer_policy {
+            write!(f, " peer policy {peer_policy}")?;
+        }
+        if !self.scrub.is_empty() {
+            write!(f, " scrub {}", self.scrub)?;
+        }
+        if !self.peer_scrub.is_empty() {
+            write!(f, " peer scrub {}", self.peer_scrub)?;
+        }
+        Ok(())
+    }
+}

--- a/src/ip/link/link_info.rs
+++ b/src/ip/link/link_info.rs
@@ -9,6 +9,7 @@ use super::ifaces::{
     bridge::{CliLinkInfoDataBridge, CliLinkInfoDataBridgePort},
     hsr::CliLinkInfoDataHsr,
     iptun::CliLinkInfoDataIpIp,
+    netkit::CliLinkInfoDataNetkit,
     veth::CliLinkInfoDataVeth,
     vlan::CliLinkInfoDataVlan,
     vxlan::CliLinkInfoDataVxlan,
@@ -95,6 +96,7 @@ impl std::fmt::Display for CliLinkInfo {
 #[derive(Serialize)]
 #[serde(untagged)]
 pub(crate) enum CliLinkInfoData {
+    Netkit(Box<CliLinkInfoDataNetkit>),
     Vlan(Box<CliLinkInfoDataVlan>),
     Veth(Box<CliLinkInfoDataVeth>),
     Bridge(Box<CliLinkInfoDataBridge>),
@@ -122,6 +124,9 @@ impl TryFrom<&InfoData> for CliLinkInfoData {
             InfoData::IpTunnel(v) => {
                 Ok(Self::IpIp(Box::new(v.as_slice().into())))
             }
+            InfoData::Netkit(v) => {
+                Ok(Self::Netkit(Box::new(v.as_slice().into())))
+            }
             _ => Err(()),
         }
     }
@@ -141,6 +146,7 @@ impl CliLinkInfoData {
 impl std::fmt::Display for CliLinkInfoData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            CliLinkInfoData::Netkit(v) => write!(f, "{v}"),
             CliLinkInfoData::Vlan(v) => write!(f, "{v}"),
             CliLinkInfoData::Veth(v) => write!(f, "{v}"),
             CliLinkInfoData::Bridge(v) => write!(f, "{v}"),

--- a/src/ip/link/tests/mod.rs
+++ b/src/ip/link/tests/mod.rs
@@ -7,6 +7,7 @@ mod dummy;
 mod hsr;
 mod ipip;
 mod loopback;
+mod netkit;
 mod nlmon;
 mod veth;
 mod vlan;

--- a/src/ip/link/tests/netkit.rs
+++ b/src/ip/link/tests/netkit.rs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MIT
+
+use crate::tests::{NetnsGuard, with_netns};
+
+const NETKIT_NAME: &str = "tnk";
+
+#[test]
+fn test_link_show_netkit() {
+    with_netkit_default(|ns| {
+        ns.assert_eq_output(&["link", "show", NETKIT_NAME]);
+    });
+}
+
+#[test]
+fn test_link_detailed_show_netkit() {
+    with_netkit_default(|ns| {
+        ns.assert_eq_output(&["-d", "link", "show", NETKIT_NAME]);
+    });
+}
+
+#[test]
+fn test_link_show_netkit_json() {
+    with_netkit_default(|ns| {
+        ns.assert_eq_output(&["-j", "link", "show", NETKIT_NAME]);
+    });
+}
+
+#[test]
+fn test_link_detailed_show_netkit_json() {
+    with_netkit_default(|ns| {
+        ns.assert_eq_output(&["-d", "-j", "link", "show", NETKIT_NAME]);
+    });
+}
+
+#[test]
+fn test_netkit_create_mode_l2() {
+    with_netns(|ns| {
+        let name = "tnk-l2";
+        ns.ip_rs_exec_cmd(&[
+            "link", "add", name, "type", "netkit", "mode", "l2",
+        ]);
+        netkit_bring_up_all(ns, name);
+
+        let outputs = ns.assert_eq_output(&["-d", "link", "show", name]);
+        assert!(outputs.expected.contains("mode l2"));
+    });
+}
+
+#[test]
+fn test_netkit_create_forward_policy() {
+    with_netns(|ns| {
+        let name = "tnk-fwd";
+        ns.ip_rs_exec_cmd(&["link", "add", name, "type", "netkit", "forward"]);
+        netkit_bring_up_all(ns, name);
+
+        let outputs = ns.assert_eq_output(&["-d", "link", "show", name]);
+        assert!(outputs.expected.contains("policy forward"));
+    });
+}
+
+#[test]
+fn test_netkit_create_blackhole_policy() {
+    with_netns(|ns| {
+        let name = "tnk-bh";
+        ns.ip_rs_exec_cmd(&[
+            "link",
+            "add",
+            name,
+            "type",
+            "netkit",
+            "blackhole",
+        ]);
+        netkit_bring_up_all(ns, name);
+
+        let outputs = ns.assert_eq_output(&["-d", "link", "show", name]);
+        assert!(outputs.expected.contains("policy blackhole"));
+    });
+}
+
+#[test]
+fn test_netkit_create_with_peer_name() {
+    with_netns(|ns| {
+        let name = "tnk-pn";
+        let peer = "tnk-pn-p";
+        ns.ip_rs_exec_cmd(&[
+            "link", "add", name, "type", "netkit", "peer", peer,
+        ]);
+        netkit_bring_up_all(ns, name);
+
+        ns.assert_eq_output(&["-d", "link", "show", name]);
+    });
+}
+
+#[test]
+fn test_netkit_create_peer_with_scrub_policy_name() {
+    with_netns(|ns| {
+        let name = "tnk-spn";
+        let peer = "tnk-spn-p";
+        ns.ip_rs_exec_cmd(&[
+            "link", "add", name, "type", "netkit", "peer", "scrub", "none",
+            "forward", peer,
+        ]);
+        netkit_bring_up_all(ns, name);
+
+        let outputs = ns.assert_eq_output(&["-d", "link", "show", name]);
+        assert!(outputs.expected.contains("peer policy forward"));
+        assert!(outputs.expected.contains("peer scrub none"));
+    });
+}
+
+#[test]
+fn test_netkit_create_peer_with_policy_name() {
+    with_netns(|ns| {
+        let name = "tnk-pn2";
+        let peer = "tnk-pn2-p";
+        ns.ip_rs_exec_cmd(&[
+            "link", "add", name, "type", "netkit", "peer", "forward", peer,
+        ]);
+        netkit_bring_up_all(ns, name);
+
+        let outputs = ns.assert_eq_output(&["-d", "link", "show", name]);
+        assert!(outputs.expected.contains("peer policy forward"));
+    });
+}
+
+fn netkit_bring_up_all(ns: &NetnsGuard, primary: &str) {
+    let output = ns.exec_cmd(&["ip", "link", "show", primary]);
+    let peer = output
+        .split_once('@')
+        .and_then(|(_, rest)| rest.split_once(':').map(|(p, _)| p.trim()));
+    if let Some(peer) = peer {
+        ns.exec_cmd(&["ip", "link", "set", peer, "up"]);
+    }
+    ns.exec_cmd(&["ip", "link", "set", primary, "up"]);
+}
+
+fn with_netkit_default<T>(test: T)
+where
+    T: FnOnce(&NetnsGuard),
+{
+    with_netns(|ns| {
+        ns.ip_rs_exec_cmd(&["link", "add", NETKIT_NAME, "type", "netkit"]);
+        netkit_bring_up_all(ns, NETKIT_NAME);
+
+        test(ns);
+    });
+}


### PR DESCRIPTION
Support creating and displaying netkit interfaces via
`ip link add <name> type netkit`. Accepts all man page
options: mode, scrub, forward/blackhole policy, peer name.

Includes integration tests comparing output against system ip.